### PR TITLE
Add getPersonList service

### DIFF
--- a/src/doc/02 - functional.rst
+++ b/src/doc/02 - functional.rst
@@ -169,6 +169,7 @@ The interfaces described in this chapter are summarized in the following table:
     Match Person Attributes             IU                          IU      U           U
     Verify Person Attributes            IU                          IU      U           U
     Get Person UIN              U       IU                          IU      U
+    Get Person List             U       IU                          IU      U
     Get document                        IU                          IU
     --------------------------- ------- ------- ----------- ------- ------- ----------- -------
     **Biometrics**

--- a/src/doc/annexes/technical/dataaccess.rst
+++ b/src/doc/annexes/technical/dataaccess.rst
@@ -12,14 +12,21 @@ Services
 .. http:get:: /v1/persons
     :synopsis: null
 
-    Retrieve a UIN based on a set of attributes.
+    Retrieve UIN or person attributes based on a set of attributes.
     This service is used when the UIN is unknown.
 
     :query object attributes:
         The attributes used to retrieve the UIN
         (Required)
+    :query array names:
+        The names of the attributes to return. If not provided, only the UIN is returned
+    :query int max:
+        The maximum number of records to return. Default is 10
     :status 200:
-        All UIN found (a list of at least one UIN)
+        The requested attributes for all found persons (a list of at least one entry).
+            
+        If no names are given, a flat list of UIN is returned.
+        If at least one name is given, a list of dictionaries (one dictionary per record) is returned.
     :status 400:
         Invalid parameter
     :status 401:
@@ -38,6 +45,12 @@ Services
         GET /v1/persons?firstName=John&lastName=Do HTTP/1.1
         Host: example.com
 
+    **Example request:**
+
+    .. sourcecode:: http
+
+        GET /v1/persons?firstName=John&lastName=Do&names=firstName&names=lastName&names=dob HTTP/1.1
+        Host: example.com
 
 
     **Example response:**
@@ -49,6 +62,24 @@ Services
 
         [
             "1235567890"
+        ]
+
+    **Example response:**
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+            {
+                "firstName": "John",
+                "lastName": "Doo",
+                "dob": {
+                    "code": 1023
+                    "message": "Unknown attribute name"
+                }
+            }
         ]
 
 

--- a/src/doc/functional/_dataaccess.rst
+++ b/src/doc/functional/_dataaccess.rst
@@ -135,6 +135,40 @@ This service is synchronous. It can be used to get the UIN of a person.
 
 -------
 
+.. py:function:: getPersonList(attributes, names)
+    :noindex:
+
+    Retrieve person attributes of records matching the provided attributes.
+    This service is proposed as an optimization of a sequence of calls to
+    :py:function:`getPersonUIN` and :py:function:`getPersonAttributes`.
+
+    **Authorization**: :todo:`To be defined`
+
+    :param list[(str,str)] attributes: The attributes to be used to find the persons. Each attribute is described with its name and its value
+    :param list[str] names: The names of the attributes requested
+    :return: a list of lists of pairs (name,value). In case of error (unknown attributes, unauthorized access, etc.) the value is replaced with an error
+
+This service is synchronous. It can be used to retrieve attributes from CR or from PR.
+
+.. uml::
+    :caption: ``getPersonList`` Sequence Diagram
+    :scale: 50%
+
+    !include "skin.iwsd"
+    hide footbox
+    participant "CR" as CR
+    participant "PR" as PR
+
+    note over CR,PR: CR can request person's attributes from PR
+    CR -> PR: getPersonList([attributes],[names])
+    PR -->> CR: [attributes]
+
+    note over CR,PR: PR can request person's attributes from CR
+    PR -> CR: getPersonList([attributes],[names])
+    CR -->> PR: [attributes]
+
+-------
+
 .. py:function:: getDocument(UINs,documentType,format)
     :noindex:
 

--- a/src/doc/functional/_dataaccess.rst
+++ b/src/doc/functional/_dataaccess.rst
@@ -140,7 +140,7 @@ This service is synchronous. It can be used to get the UIN of a person.
 
     Retrieve person attributes of records matching the provided attributes.
     This service is proposed as an optimization of a sequence of calls to
-    :py:function:`getPersonUIN` and :py:function:`getPersonAttributes`.
+    :py:func:`getPersonUIN` and :py:func:`getPersonAttributes`.
 
     **Authorization**: :todo:`To be defined`
 

--- a/src/doc/yaml/dataaccess.yaml
+++ b/src/doc/yaml/dataaccess.yaml
@@ -1,9 +1,17 @@
 openapi: 3.0.0
 info:
   title: OSIA data access services
-  version: 1.0.0
+  version: 1.1.0
+  description: |
+    The OSIA Data Access interface.
+    
+    Change log:
+    
+    - 1.1.0: extended getPersonUIN/getPersonList operation to return a list of attributes, and not only a list of UIN
+    - 1.0.0: first version proposed in OSIA.
+    
 servers:
-  - url: http://server.com/
+  - url: http://registry.com/
 tags:
   - name: Person
   - name: Document
@@ -11,16 +19,16 @@ paths:
   /v1/persons:
     get:
       description: |
-        Retrieve a UIN based on a set of attributes.
+        Retrieve UIN or person attributes based on a set of attributes.
         This service is used when the UIN is unknown.
-        Example: http://registry.com/v1/persons?firstName=John&lastName=Do
-      operationId: getPersonUIN
+        Example: http://registry.com/v1/persons?firstName=John&lastName=Do&names=firstName
+      operationId: getPersonList
       tags:
       - Person
       parameters: 
         - name: attributes
           in: query
-          description: The attributes used to retrieve the UIN
+          description: The attributes (names and values) used to retrieve the UIN
           required: true
           schema:
             type: object
@@ -30,19 +38,61 @@ paths:
           example:
             firstName: John
             lastName: Do
-                        
+        - name: names
+          in: query
+          description: The names of the attributes to return. If not provided, only the UIN is returned
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          example:
+            - firstName
+            - lastName
+        - name: max
+          in: query
+          description: The maximum number of records to return. Default is 10.
+          required: false
+          schema:
+            type: number
+
       responses:
         200:
-          description: All UIN found (a list of at least one UIN)
+          description: >
+            The requested attributes for all found persons (a list of at least one entry).
+            
+            If no names are given, a flat list of UIN is returned.
+            If at least one name is given, a list of dictionaries (one dictionary per record) is returned.
           content:
             application/json:
               schema:
-                type: array
-                minimum: 1
-                items:
-                  type: string
-              example:
-                - "1235567890"
+                oneOf:
+                - type: array
+                  minimum: 1
+                  items:
+                    type: string
+                  example:
+                    - "1235567890"
+                - type: array
+                  minimum: 1
+                  items:
+                    type: object
+                    additionalProperties:
+                      oneOf:
+                      - type: string
+                      - type: integer
+                      - type: number
+                      - type: boolean
+                      - $ref: '#/components/schemas/Error'
+                    example:
+                      firstName: John
+                      lastName: Doo
+                      dob:
+                        code: 1023
+                        message: Unknown attribute name
+                    
         400:
           description: Invalid parameter
         401:
@@ -50,7 +100,7 @@ paths:
         403:
           description: Service forbidden
         404:
-          description: No UIN found
+          description: No record found
         500:
           description: Unexpected error
           content:
@@ -313,8 +363,7 @@ components:
         - type: number
         - type: boolean
       # Or ?:
-      #additionalProperties:
-      #  type: string
+      #additionalProperties: true
     Expression:
       type: object
       required:

--- a/src/doc/yaml/dataaccess.yaml
+++ b/src/doc/yaml/dataaccess.yaml
@@ -53,7 +53,7 @@ paths:
             - lastName
         - name: max
           in: query
-          description: The maximum number of records to return. Default is 10.
+          description: The maximum number of records to return. Default is 10
           required: false
           schema:
             type: number


### PR DESCRIPTION
As discussed during a workshop held on the 3rd of Sept, 2019, this PR proposes the addition of a `getPersonList` service in the data access interface.

In the HTTP/REST interface, this new service is merged with `getPersonUIN`: both are accessible with the same URL and operation:
`GET /v1/persons
`