### PR TITLE
Rename 'subject' to 'person' in ABIS interface

### DIFF
--- a/src/doc/annexes/technical/abis.rst
+++ b/src/doc/annexes/technical/abis.rst
@@ -12,13 +12,13 @@ Services
 CRUD
 ''''
 
-.. http:get:: /v1/subjects/{subjectId}/{encounterId}/templates
+.. http:get:: /v1/persons/{personId}/{encounterId}/templates
     :synopsis: Get biometrics templates
 
     **Get biometrics templates**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :param string encounterId:
         the id of the encounter
     :query string biometricType:
@@ -53,7 +53,7 @@ CRUD
 
     .. sourcecode:: http
 
-        GET /v1/subjects/{subjectId}/{encounterId}/templates HTTP/1.1
+        GET /v1/persons/{personId}/{encounterId}/templates HTTP/1.1
         Host: example.com
 
 
@@ -155,13 +155,13 @@ CRUD
 
 
 
-.. http:post:: /v1/subjects/{subjectId}/{encounterId}
+.. http:post:: /v1/persons/{personId}/{encounterId}
     :synopsis: Insert one encounter
 
     **Insert one encounter**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :param string encounterId:
         the id of the encounter
     :query string transactionId:
@@ -188,7 +188,7 @@ CRUD
 
     .. sourcecode:: http
 
-        POST /v1/subjects/{subjectId}/{encounterId} HTTP/1.1
+        POST /v1/persons/{personId}/{encounterId} HTTP/1.1
         Host: example.com
         Content-Type: application/json
 
@@ -277,7 +277,7 @@ CRUD
 
             {
                 "status": "OK",
-                "subjectId": "string",
+                "personId": "string",
                 "encounterId": "string"
             }
 
@@ -296,13 +296,13 @@ CRUD
 
 
 
-.. http:get:: /v1/subjects/{subjectId}/{encounterId}
+.. http:get:: /v1/persons/{personId}/{encounterId}
     :synopsis: Read one encounter
 
     **Read one encounter**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :param string encounterId:
         the id of the encounter
     :query string transactionId:
@@ -329,7 +329,7 @@ CRUD
 
     .. sourcecode:: http
 
-        GET /v1/subjects/{subjectId}/{encounterId} HTTP/1.1
+        GET /v1/persons/{personId}/{encounterId} HTTP/1.1
         Host: example.com
 
 
@@ -474,13 +474,13 @@ CRUD
 
 
 
-.. http:put:: /v1/subjects/{subjectId}/{encounterId}
+.. http:put:: /v1/persons/{personId}/{encounterId}
     :synopsis: Update one encounter
 
     **Update one encounter**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :param string encounterId:
         the id of the encounter
     :query string transactionId:
@@ -509,7 +509,7 @@ CRUD
 
     .. sourcecode:: http
 
-        PUT /v1/subjects/{subjectId}/{encounterId} HTTP/1.1
+        PUT /v1/persons/{personId}/{encounterId} HTTP/1.1
         Host: example.com
         Content-Type: application/json
 
@@ -613,13 +613,13 @@ CRUD
 
 
 
-.. http:delete:: /v1/subjects/{subjectId}/{encounterId}
+.. http:delete:: /v1/persons/{personId}/{encounterId}
     :synopsis: Delete one encounter
 
     **Delete one encounter**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :param string encounterId:
         the id of the encounter
     :query string transactionId:
@@ -707,10 +707,10 @@ CRUD
 
 
 
-.. http:post:: /v1/subjects
-    :synopsis: Insert one encounter and generate ID for both the subject and the encounter
+.. http:post:: /v1/persons
+    :synopsis: Insert one encounter and generate ID for both the person and the encounter
 
-    **Insert one encounter and generate ID for both the subject and the encounter**
+    **Insert one encounter and generate ID for both the person and the encounter**
 
     :query string transactionId:
         The id of the transaction
@@ -736,7 +736,7 @@ CRUD
 
     .. sourcecode:: http
 
-        POST /v1/subjects HTTP/1.1
+        POST /v1/persons HTTP/1.1
         Host: example.com
         Content-Type: application/json
 
@@ -784,7 +784,7 @@ CRUD
 
         {
             "status": "OK",
-            "subjectId": "string",
+            "personId": "string",
             "encounterId": "string"
         }
 
@@ -839,7 +839,7 @@ CRUD
 
             {
                 "status": "OK",
-                "subjectId": "string",
+                "personId": "string",
                 "encounterId": "string"
             }
 
@@ -858,13 +858,13 @@ CRUD
 
 
 
-.. http:get:: /v1/subjects/{subjectId}
-    :synopsis: Read all encounters of one subject
+.. http:get:: /v1/persons/{personId}
+    :synopsis: Read all encounters of one person
 
-    **Read all encounters of one subject**
+    **Read all encounters of one person**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :query string transactionId:
         The id of the transaction
     :query string callback:
@@ -889,7 +889,7 @@ CRUD
 
     .. sourcecode:: http
 
-        GET /v1/subjects/{subjectId} HTTP/1.1
+        GET /v1/persons/{personId} HTTP/1.1
         Host: example.com
 
 
@@ -1039,13 +1039,13 @@ CRUD
 
 
 
-.. http:post:: /v1/subjects/{subjectId}
+.. http:post:: /v1/persons/{personId}
     :synopsis: Insert one encounter and generate its ID
 
     **Insert one encounter and generate its ID**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :query string transactionId:
         The id of the transaction
     :query string callback:
@@ -1070,7 +1070,7 @@ CRUD
 
     .. sourcecode:: http
 
-        POST /v1/subjects/{subjectId} HTTP/1.1
+        POST /v1/persons/{personId} HTTP/1.1
         Host: example.com
         Content-Type: application/json
 
@@ -1118,7 +1118,7 @@ CRUD
 
         {
             "status": "OK",
-            "subjectId": "string",
+            "personId": "string",
             "encounterId": "string"
         }
 
@@ -1173,7 +1173,7 @@ CRUD
 
             {
                 "status": "OK",
-                "subjectId": "string",
+                "personId": "string",
                 "encounterId": "string"
             }
 
@@ -1192,13 +1192,13 @@ CRUD
 
 
 
-.. http:delete:: /v1/subjects/{subjectId}
-    :synopsis: Delete a subject and all its encounters
+.. http:delete:: /v1/persons/{personId}
+    :synopsis: Delete a person and all its encounters
 
-    **Delete a subject and all its encounters**
+    **Delete a person and all its encounters**
 
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :query string transactionId:
         The id of the transaction
     :query string callback:
@@ -1443,7 +1443,7 @@ Gallery
 
         [
             {
-                "subjectId": "string",
+                "personId": "string",
                 "encounterId": "string"
             }
         ]
@@ -1499,7 +1499,7 @@ Gallery
 
             [
                 {
-                    "subjectId": "string",
+                    "personId": "string",
                     "encounterId": "string"
                 }
             ]
@@ -1596,7 +1596,7 @@ Search
 
         [
             {
-                "subjectId": "string",
+                "personId": "string",
                 "rank": 1,
                 "score": 1.0,
                 "scoreList": [
@@ -1661,7 +1661,7 @@ Search
 
             [
                 {
-                    "subjectId": "string",
+                    "personId": "string",
                     "rank": 1,
                     "score": 1.0,
                     "scoreList": [
@@ -1690,7 +1690,7 @@ Search
 
 
 
-.. http:post:: /v1/identify/{galleryId}/{subjectId}
+.. http:post:: /v1/identify/{galleryId}/{personId}
     :synopsis: Biometric identification
 
     **Biometric identification**
@@ -1699,8 +1699,8 @@ Search
 
     :param string galleryId:
         the id of the gallery
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :query string transactionId:
         The id of the transaction
     :query string callback:
@@ -1729,7 +1729,7 @@ Search
 
     .. sourcecode:: http
 
-        POST /v1/identify/{galleryId}/{subjectId} HTTP/1.1
+        POST /v1/identify/{galleryId}/{personId} HTTP/1.1
         Host: example.com
         Content-Type: application/json
 
@@ -1748,7 +1748,7 @@ Search
 
         [
             {
-                "subjectId": "string",
+                "personId": "string",
                 "rank": 1,
                 "score": 1.0,
                 "scoreList": [
@@ -1813,7 +1813,7 @@ Search
 
             [
                 {
-                    "subjectId": "string",
+                    "personId": "string",
                     "rank": 1,
                     "score": 1.0,
                     "scoreList": [
@@ -1842,7 +1842,7 @@ Search
 
 
 
-.. http:post:: /v1/verify/{galleryId}/{subjectId}
+.. http:post:: /v1/verify/{galleryId}/{personId}
     :synopsis: Biometric verification
 
     **Biometric verification**
@@ -1851,8 +1851,8 @@ Search
 
     :param string galleryId:
         the id of the gallery
-    :param string subjectId:
-        the id of the subject
+    :param string personId:
+        the id of the person
     :query string transactionId:
         The id of the transaction
     :query string callback:
@@ -1881,7 +1881,7 @@ Search
 
     .. sourcecode:: http
 
-        POST /v1/verify/{galleryId}/{subjectId} HTTP/1.1
+        POST /v1/verify/{galleryId}/{personId} HTTP/1.1
         Host: example.com
         Content-Type: application/json
 

--- a/src/doc/functional/_abis.rst
+++ b/src/doc/functional/_abis.rst
@@ -30,14 +30,14 @@ See :ref:`annex-interface-abis` for the technical details of this interface.
 Services
 """"""""
 
-.. py:function:: insert(subjectID, encounterID, galleryID, biographicData, contextualData, biometricData, clientData,callback, options)
+.. py:function:: insert(personID, encounterID, galleryID, biographicData, contextualData, biometricData, clientData,callback, options)
     :noindex:
 
     Insert a new encounter. No identify is performed. This service is synchronous.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param str encounterID: The encounter ID. This is optional
     :param list(str) galleryID: the gallery ID to which this encounter belongs
     :param dict biographicData: The biographic data (ex: name, date of birth, gender, etc.)
@@ -48,33 +48,33 @@ Services
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``, ``algorithm``.
     :return: a status indicating success, error, or pending operation.
-        In case of success, the subject ID and the encounter ID are returned.
+        In case of success, the person ID and the encounter ID are returned.
         In case of pending operation, the result will be sent later.
 
-.. py:function:: read(subjectID, encounterID, callback, options)
+.. py:function:: read(personID, encounterID, callback, options)
     :noindex:
 
     Retrieve the data of an encounter.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param str encounterID: The encounter ID. This is optional. If not provided, all the
-        encounters of the subject are returned.
+        encounters of the person are returned.
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``.
     :return: a status indicating success, error, or pending operation.
         In case of success, the encounter data is returned.
         In case of pending operation, the result will be sent later.
 
-.. py:function:: update(subjectID, encounterID, galleryID, biographicData, contextualData, biometricData, callback, options)
+.. py:function:: update(personID, encounterID, galleryID, biographicData, contextualData, biometricData, callback, options)
     :noindex:
 
     Update an encounter.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param str encounterID: The encounter ID
     :param list(str) galleryID: the gallery ID to which this encounter belongs
     :param dict biographicData: The biographic data (ex: name, date of birth, gender, etc.)
@@ -85,34 +85,34 @@ Services
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``, ``algorithm``.
     :return: a status indicating success, error, or pending operation.
-        In case of success, the subject ID and the encounter ID are returned.
+        In case of success, the person ID and the encounter ID are returned.
         In case of pending operation, the result will be sent later.
 
-.. py:function:: delete(subjectID, encounterID, callback, options)
+.. py:function:: delete(personID, encounterID, callback, options)
     :noindex:
 
     Delete an encounter.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param str encounterID: The encounter ID. This is optional. If not provided, all the
-        encounters of the subject are deleted.
+        encounters of the person are deleted.
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``.
     :return: a status indicating success, error, or pending operation.
         In case of pending operation, the operation status will be sent later.
 
-.. py:function:: getTemplate(subjectID, encounterID, biometricType, biometricSubType, callback, options)
+.. py:function:: getTemplate(personID, encounterID, biometricType, biometricSubType, callback, options)
     :noindex:
 
     Retrieve the data of an encounter.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param str encounterID: The encounter ID. This is optional. If not provided, all the
-        encounters of the subject are returned.
+        encounters of the person are returned.
     :param str biometricType: The type of biometrics to consider
     :param str biometricSubType: The subtype of biometrics to consider
     :param callback: The address of a service to be called when the result is available.
@@ -127,7 +127,7 @@ Services
 .. py:function:: identify(galleryID, filter, biometricData, callback, options)
     :noindex:
 
-    Identify a subject using biometrics data and filters on biographic or contextual data. This may include multiple
+    Identify a person using biometrics data and filters on biographic or contextual data. This may include multiple
     operations, including manual operations.
 
     **Authorization**: :todo:`To be defined`
@@ -141,33 +141,33 @@ Services
     :return: a status indicating success, error, or pending operation.
         A list of candidates is returned, either synchronously or using the callback.
 
-.. py:function:: identify(galleryID, filter, subjectID, callback, options)
+.. py:function:: identify(galleryID, filter, personID, callback, options)
     :noindex:
 
-    Identify a subject using biometrics data of a subject existing in the system and filters on biographic or
+    Identify a person using biometrics data of a person existing in the system and filters on biographic or
     contextual data. This may include multiple operations, including manual operations.
 
     **Authorization**: :todo:`To be defined`
 
     :param str galleryID: Search only in this gallery.
     :param dict filter: The input data (filters and biometric data)
-    :param subjectID: the subject ID
+    :param personID: the person ID
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``,
         ``maxNbCand``, ``threshold``, ``accuracyLevel``.
     :return: a status indicating success, error, or pending operation.
         A list of candidates is returned, either synchronously or using the callback.
 
-.. py:function:: verify(galleryID, subjectID, biometricData, callback, options)
+.. py:function:: verify(galleryID, personID, biometricData, callback, options)
     :noindex:
 
     Verify an identity using biometrics data.
 
     **Authorization**: :todo:`To be defined`
 
-    :param str galleryID: Search only in this gallery. If the subject does not belong to this gallery,
+    :param str galleryID: Search only in this gallery. If the person does not belong to this gallery,
         an error is returned.
-    :param str subjectID: The subject ID
+    :param str personID: The person ID
     :param biometricData: The biometric data
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``,
@@ -179,7 +179,7 @@ Services
 .. py:function:: verify(biometricData1, biometricData2, callback, options)
     :noindex:
 
-    Verify that two sets of biometrics data correspond to the same subject.
+    Verify that two sets of biometrics data correspond to the same person.
 
     **Authorization**: :todo:`To be defined`
 
@@ -217,7 +217,7 @@ Services
     :param callback: The address of a service to be called when the result is available.
     :param dict options: the processing options. Supported options are ``transactionID``, ``priority``.
     :return: a status indicating success, error, or pending operation.
-        A list of subjects/encounters is returned, either synchronously or using the callback.
+        A list of persons/encounters is returned, either synchronously or using the callback.
 
 
 Options
@@ -259,16 +259,16 @@ Data Model
       - Example
 
     * - Gallery
-      - A group of subjects related by a common purpose, designation, or status.
-        A subject can belong to multiple galleries.
+      - A group of persons related by a common purpose, designation, or status.
+        A person can belong to multiple galleries.
       - :todo:`TBD`
 
-    * - Subject
+    * - Person
       - Person who is known to an identity assurance system.
       - :todo:`TBD`
 
     * - Encounter
-      - Event in which the client application interacts with a subject resulting in data being
+      - Event in which the client application interacts with a person resulting in data being
         collected during or about the encounter. An encounter is characterized by an *identifier* and a *type*
         (also called *purpose* in some context).
       - :todo:`TBD`
@@ -315,11 +315,11 @@ Data Model
         string galleryID;
     }
 
-    class Subject {
-        string subjectID;
+    class Person {
+        string personID;
     }
 
-    Subject "*" - "*" Gallery
+    Person "*" - "*" Gallery
 
     class Encounter {
         string encounterID;
@@ -327,7 +327,7 @@ Data Model
         byte[] clientData;
     }
 
-    Subject o-- "*" Encounter
+    Person o-- "*" Encounter
 
     class BiographicData {
         string field1;
@@ -398,7 +398,7 @@ Data Model
       int rank;
       int score;
     }
-    Candidate . Subject
+    Candidate . Person
 
     class CandidateScore {
       int score;

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -11,16 +11,16 @@ servers:
   - url: http://abis.com/
   - url: https://abis.com/
 paths:
-  /v1/subjects/{subjectId}/{encounterId}/templates:
+  /v1/persons/{personId}/{encounterId}/templates:
     get:
       tags:
         - CRUD
       summary: Get biometrics templates
       operationId: getTemplate
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -147,16 +147,16 @@ paths:
                       schema:
                         $ref: '#/components/schemas/Error'
 
-  /v1/subjects/{subjectId}/{encounterId}:
+  /v1/persons/{personId}/{encounterId}:
     post:
       tags:
         - CRUD
       summary: Insert one encounter
       operationId: insert
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -256,7 +256,7 @@ paths:
                         status:
                           type: string
                           enum: [OK, ERROR]
-                        subjectId:
+                        personId:
                           type: string
                         encounterId:
                           type: string
@@ -277,9 +277,9 @@ paths:
       summary: Read one encounter
       operationId: read
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -395,9 +395,9 @@ paths:
       summary: Update one encounter
       operationId: update
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -511,9 +511,9 @@ paths:
       summary: Delete one encounter
       operationId: delete
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -601,11 +601,11 @@ paths:
                       schema:
                         $ref: '#/components/schemas/Error'
 
-  /v1/subjects:
+  /v1/persons:
     post:
       tags:
         - CRUD
-      summary: Insert one encounter and generate ID for both the subject and the encounter
+      summary: Insert one encounter and generate ID for both the person and the encounter
       operationId: insertNoIds
       parameters:
         - name: transactionId
@@ -663,7 +663,7 @@ paths:
                   status:
                     type: string
                     enum: [OK, ERROR]
-                  subjectId:
+                  personId:
                     type: string
                   encounterId:
                     type: string
@@ -714,7 +714,7 @@ paths:
                         status:
                           type: string
                           enum: [OK, ERROR]
-                        subjectId:
+                        personId:
                           type: string
                         encounterId:
                           type: string
@@ -730,16 +730,16 @@ paths:
                       schema:
                         $ref: '#/components/schemas/Error'
 
-  /v1/subjects/{subjectId}:
+  /v1/persons/{personId}:
     get:
       tags:
         - CRUD
-      summary: Read all encounters of one subject
+      summary: Read all encounters of one person
       operationId: readAll
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -853,9 +853,9 @@ paths:
       summary: Insert one encounter and generate its ID
       operationId: insertNoId
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -914,7 +914,7 @@ paths:
                   status:
                     type: string
                     enum: [OK, ERROR]
-                  subjectId:
+                  personId:
                     type: string
                   encounterId:
                     type: string
@@ -965,7 +965,7 @@ paths:
                         status:
                           type: string
                           enum: [OK, ERROR]
-                        subjectId:
+                        personId:
                           type: string
                         encounterId:
                           type: string
@@ -983,12 +983,12 @@ paths:
     delete:
       tags:
         - CRUD
-      summary: Delete a subject and all its encounters
+      summary: Delete a person and all its encounters
       operationId: deleteAll
       parameters:
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -1200,7 +1200,7 @@ paths:
                       schema:
                         $ref: '#/components/schemas/Error'
 
-  /v1/identify/{galleryId}/{subjectId}:
+  /v1/identify/{galleryId}/{personId}:
     post:
       tags:
         - Search
@@ -1214,9 +1214,9 @@ paths:
           required: true
           schema:
             type: string
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -1326,7 +1326,7 @@ paths:
                       schema:
                         $ref: '#/components/schemas/Error'
 
-  /v1/verify/{galleryId}/{subjectId}:
+  /v1/verify/{galleryId}/{personId}:
     post:
       tags:
         - Search
@@ -1340,9 +1340,9 @@ paths:
           required: true
           schema:
             type: string
-        - name: subjectId
+        - name: personId
           in: path
-          description: the id of the subject
+          description: the id of the person
           required: true
           schema:
             type: string
@@ -1736,10 +1736,10 @@ paths:
                 items:
                   type: object
                   required:
-                    - subjectId
+                    - personId
                     - encounterId
                   properties:
-                    subjectId:
+                    personId:
                       type: string
                     encounterId:
                       type: string
@@ -1788,10 +1788,10 @@ paths:
                       items:
                         type: object
                         required:
-                          - subjectId
+                          - personId
                           - encounterId
                         properties:
-                          subjectId:
+                          personId:
                             type: string
                           encounterId:
                             type: string
@@ -2033,13 +2033,13 @@ components:
     Candidate:
       type: object
       required:
-        - subjectId
+        - personId
         - rank
         - score
       properties:
-        subjectId:
+        personId:
           type: string
-          description: the identifier of the subject
+          description: the identifier of the person
         rank:
           type: integer
           format: int32


### PR DESCRIPTION
As discussed during a workshop held on the 3rd of Sept, 2019, this PR proposes a change of vocabulary for the ABIS interface: all occurrences of `subject` are replaced by `person`.
