### PR TITLE
Merge services for PR and ABIS

### DIFF
--- a/src/doc/02 - functional.rst
+++ b/src/doc/02 - functional.rst
@@ -218,6 +218,7 @@ The following table describes in detail the interfaces and associated services.
     Read Person                        Read the attributes of a person
     Update Person                      Update a person
     Delete Person                      Delete a person and all its identities
+    Merge Persons                      Merge two persons
     Create Identity                    Create a new identity in a person
     Read Identity                      Read one or all the identities of one person
     Update Identity                    Update an identity. An identity can be updated only in the status claimed
@@ -235,6 +236,7 @@ The following table describes in detail the interfaces and associated services.
     Read                               Read the data of an encounter
     Update                             Update an encounter
     Delete                             Delete an encounter
+    Merge                              Merge two sets of encounters
     Read Template                      Read the generated template
     Read Galleries                     Read the ID of all the galleries
     Read Gallery content               Read the content of one gallery, i.e. the IDs of all the records linked to this gallery
@@ -328,10 +330,11 @@ The interfaces described in the following chapter can be mapped against ID ecosy
     ---------------------------------  ------- ------- ------- ------- ------- ------- -------
     **Population Registry Services**
     ------------------------------------------------------------------------------------------
-    Create Person                                I               I                U
-    Read Person                                  I               I                U       U
-    Update Person                                I               I                U
-    Delete Person                                I               I                U
+    Create Person                                I               U                U
+    Read Person                                  I               U                U       U
+    Update Person                                I               U                U
+    Delete Person                                I               U                U
+    Merge Person                                 I               U
     Create Identity                              I
     Read Identity                                I
     Update Identity                              I
@@ -349,6 +352,7 @@ The interfaces described in the following chapter can be mapped against ID ecosy
     Read                                 U       U                I                      U
     Update                               U       U                I
     Delete                               U       U                I
+    Merge                                        U                I
     Read Template                        U       U                I
     Read Galleries
     Read Gallery Content                 U       U                I

--- a/src/doc/functional/_abis.rst
+++ b/src/doc/functional/_abis.rst
@@ -33,7 +33,7 @@ Services
 .. py:function:: create(personID, encounterID, galleryID, biographicData, contextualData, biometricData, clientData,callback, transactionID, options)
     :noindex:
 
-    Create a new encounter. No identify is performed. This service is synchronous.
+    Create a new encounter. No identify is performed.
 
     **Authorization**: :todo:`To be defined`
 
@@ -106,6 +106,22 @@ Services
     :param dict options: the processing options. Supported options are ``priority``.
     :return: a status indicating success, error, or pending operation.
         In case of pending operation, the operation status will be sent later.
+
+.. py:function:: merge(personID1, personID2, callback, transactionID, options)
+    :noindex:
+
+    Merge two sets of encounters into a single one. Encounter ID are preserved and in case of duplicates
+    an error is returned and no changes are done.
+
+    **Authorization**: :todo:`To be defined`
+
+    :param str personID1: The ID of the person that will receive new encounters
+    :param str personID2: The ID of the person that will give its encounters
+    :param callback: The address of a service to be called when the result is available.
+    :param str transactionID: A free text used to track the system activities related to the same transaction.
+    :param dict options: the processing options. Supported options are ``priority``.
+    :return: a status indicating success, error, or pending operation.
+        In case of pending operation, the result will be sent later.
 
 .. py:function:: readTemplate(personID, encounterID, biometricType, biometricSubType, callback, transactionID, options)
     :noindex:

--- a/src/doc/functional/_pr.rst
+++ b/src/doc/functional/_pr.rst
@@ -66,6 +66,21 @@ Services
     :param str transactionID: A free text used to track the system activities related to the same transaction.
     :return: a status indicating success or error.
 
+.. py:function:: mergePerson(personID1, personID2, transactionID)
+    :noindex:
+
+    Merge two person records into a single one. Identity ID are preserved and in case of duplicates
+    an error is returned and no changes are done.
+    The reference identity is not changed.
+
+    **Authorization**: :todo:`To be defined`
+
+    :param str personID1: The ID of the person that will receive new identities
+    :param str personID2: The ID of the person that will give its identities. It will be deleted if the move of all identities is successful.
+    :param str transactionID: A free text used to track the system activities related to the same transaction.
+    :param dict options: the processing options. Supported options are ``priority``.
+    :return: a status indicating success or error.
+
 ----------
 
 .. py:function:: createIdentity(personID, identityID, identity, transactionID)

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: OSIA ABIS Interface
-  version: 1.1.0
+  version: 1.2.0
   title: OSIA ABIS Interface
 tags:
   - name: CRUD
@@ -533,6 +533,109 @@ paths:
               requestBody:
                 required: true
                 description: Result of the deletion
+                content:
+                  application/json:
+                    schema:
+                      type: string
+                      enum: [OK]
+                  application/error+json:
+                    schema:
+                      $ref: '#/components/schemas/Error'
+              responses:
+                '204':
+                  description: Response is received and accepted.
+                '403':
+                  description: Forbidden access to the service
+                '500':
+                  description: Unexpected error
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Error'
+
+  /v1/persons/{personIdTarget}/merge/{personIdSource}:
+    post:
+      tags:
+        - CRUD
+      summary: Merge two sets of encounters
+      description: |
+        Merge two sets of encounters into a single one. Encounter ID are preserved and in case of duplicates
+        an error is returned and no changes are done.
+      operationId: merge
+      parameters:
+        - name: personIdTarget
+          in: path
+          description: the id of the person receiving new encounters
+          required: true
+          schema:
+            type: string
+        - name: personIdSource
+          in: path
+          description: the id of the person giving the encounters
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+        - name: callback
+          in: query
+          description: the callback address, where the result will be sent when available
+          required: false
+          schema:
+            type: string
+            format: uri
+            example: "http://client.com/callback"
+        - name: priority
+          in: query
+          description: the request priority
+          required: false
+          schema:
+            type: integer
+      responses:
+        '202':
+          description: |
+            Request received successfully and correct, result will be returned through the callback.
+            The transaction ID is returned
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "123e4567-e89b-12d3-a456-426655440000"
+        '204':
+          description: Merge successful
+        '400':
+          description: Bad request
+        '403':
+          description: Merge not allowed
+        '404':
+          description: Unknown record
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      callbacks:
+        mergeResponse:
+          '${request.query.callback}':
+            post:
+              summary: Merge two persons response callback
+              operationId: mergeCB
+              parameters:
+                # query parameters
+                - name: transactionId
+                  in: query
+                  required: true
+                  description: The id of the transaction
+                  schema:
+                    type: string
+              requestBody:
+                required: true
+                description: Result of the merge
                 content:
                   application/json:
                     schema:

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: OSIA PR Interface
-  version: 1.0.0
+  version: 1.1.0
   title: OSIA Population Registry Interface
 tags:
   - name: Person
@@ -150,6 +150,51 @@ paths:
           description: Bad request
         '403':
           description: Delete not allowed
+        '404':
+          description: Unknown record
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/persons/{personIdTarget}/merge/{personIdSource}:
+    post:
+      tags:
+        - Person
+      summary: Merge two persons
+      description: |
+        Merge two person records into a single one. Identity ID are preserved and in case of duplicates
+        an error is returned and no changes are done.
+        If the operation is successful, the person merged is deleted.
+      operationId: mergePerson
+      parameters:
+        - name: personIdTarget
+          in: path
+          description: the id of the person receiving new identities
+          required: true
+          schema:
+            type: string
+        - name: personIdSource
+          in: path
+          description: the id of the person giving the identities
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Merge successful
+        '400':
+          description: Bad request
+        '403':
+          description: Merge not allowed
         '404':
           description: Unknown record
         '500':


### PR DESCRIPTION
Proposition for a merge service in both ABIS & PR.
When a duplicate is detected (and this can happen anytime during the life of the system) these two service can be used to merge the two records while keeping existing data and history of processing.