### PR TITLE
3rd PS should be able to use interfaces from CMS

### DIFF
--- a/src/doc/02 - functional.rst
+++ b/src/doc/02 - functional.rst
@@ -380,10 +380,10 @@ The interfaces described in the following chapter can be mapped against ID ecosy
     Read Credential Request                                                               I
     Update Credential Request                                                             I
     Delete Credential Request                                                             I
-    Read Credential                                                                       I
-    Suspend Credential                                                                    I
-    Unsuspend Credential                                                                  I
-    Cancel Credential                                                                     I
+    Read Credential                                                                       I      U
+    Suspend Credential                                                                    I      U
+    Unsuspend Credential                                                                  I      U
+    Cancel Credential                                                                     I       
     ---------------------------------  ------- ------- ------- ------- ------- ------- ------- -------
     **ID Usage**
     --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
At least 3 Interfaces of CMS should be usable by 3rd Party Services.

There are many use-cases where this would be beneficial, e.g. for implementing a mobile driver's license as defined in https://www.iso.org/standard/69084.html

The "suspend" interface could be used by road-side check apps used by police.