### PR TITLE
Allow 3rd Party Services full usage of Data Access Interface

### DIFF
--- a/src/doc/02 - functional.rst
+++ b/src/doc/02 - functional.rst
@@ -314,9 +314,9 @@ The interfaces described in the following chapter can be mapped against ID ecosy
      Read Person Attributes                       U      IU               U       IU              U
      Match Person Attributes                      U      IU                       IU              U
      Verify Person Attributes                     U      IU                       IU              U
-     Query Person UIN                             U      IU                       IU
-     Query Person List                                                            U
-     Read Document                                U      IU                       IU
+     Query Person UIN                             U      IU                       IU              U
+     Query Person List                                                            U               U
+     Read Document                                U      IU                       IU              U
     ---------------------------------  ------- ------- ------- ------- ------- ------- ------- -------
     **UIN Management**
     --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**What was changed:**
- allow 3rd Party Services to query a person's UIN by providing a set of attributes
- allow 3rd Party Services to query a list of persons by providing a set of attributes
- allow 3rd Party Services to read Documents 

**Possible Use-Cases**
In order to build a mobile driving license application (mDL) as specified in [ISO 18013-5](https://www.iso.org/standard/69084.html) on top of OSIA, these endpoints are required by the system that issues the mDLs. From the OSIA point of view, the mDL-enrolment-system is seen as a 3rd Party Service. The mdl-enrolment-system must also be able to retrieve images or documents (e.g. driver's license) from the *Read Document* interface in order to issue an mDL. 

**Security Considerations**
- Authorization and authentication between 3rd Party Service and Data Access API is out of scope of this Pull Request. General [OSIA Security considerations](https://osia.readthedocs.io/en/latest/03%20-%20security.html#authorization) apply.