### PR TITLE
Notification  : change part "confirm the address before the subscription is active"

### DIFF
--- a/src/doc/functional/_notification.rst
+++ b/src/doc/functional/_notification.rst
@@ -37,12 +37,12 @@ in the following diagram:
 
     note over N,CR: confirm the address before the subscription is active
 
-    N -> CR: notify(token)
+    N -> CR: confirm(token)
     activate N
     activate CR
-    CR -> N: subscribe_CB(token)
+    N -> CR: subscribe_CB(token)
     activate N #FFBBB
-    N --> CR: ok
+    CR --> N: ok
     deactivate N
     CR --> N: ok
     deactivate CR

--- a/src/doc/functional/_notification.rst
+++ b/src/doc/functional/_notification.rst
@@ -37,12 +37,12 @@ in the following diagram:
 
     note over N,CR: confirm the address before the subscription is active
 
-    N -> CR: confirm(token)
+    N -> CR: subscribe_CB(message)
     activate N
     activate CR
-    N -> CR: subscribe_CB(token)
-    activate N #FFBBB
-    CR --> N: ok
+    CR -> N: confirm(token)
+    activate N #FFBBBB
+    N --> CR: ok
     deactivate N
     CR --> N: ok
     deactivate CR


### PR DESCRIPTION
- Use confirm instead of notify
- Change arrow direction from N to CR. This way, Notification Engine can use the previously registered callback and check if url is working.