### PR TITLE
Update dataaccess.rst

### DIFF
--- a/src/doc/annexes/technical/dataaccess.rst
+++ b/src/doc/annexes/technical/dataaccess.rst
@@ -18,6 +18,7 @@ Data Access
         :columns: 2
 
         - `queryPersonList <#get--v1-persons>`_
+        - `queryPersonUIN <#get--v1-persons>`_
         - `readPersonAttributes <#get--v1-persons-uin>`_
         - `matchPersonAttributes <#post--v1-persons-uin-match>`_
         - `verifyPersonAttributes <#post--v1-persons-uin-verify>`_


### PR DESCRIPTION
QueryPersonUIN is described in the interface part : https://osia.readthedocs.io/en/latest/05%20-%20interfaces.html#id1
without his technical implementation in the annexe part : https://osia.readthedocs.io/en/stable/annexes/technical/dataaccess.html#get--v1-persons.
We can produce fonctionnal result of QueryPersonUIN with the service "GET /v1/persons" (same as QueryPersonList) if we not provide "names" param during call. I suggest to add the link of QueryPersonUIN to this webservice implementation.