### PR TITLE
Adv authent

### DIFF
--- a/src/doc/yaml/authenticate.yaml
+++ b/src/doc/yaml/authenticate.yaml
@@ -1,22 +1,57 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
-  title: authenticate
-  version: '1.0'
-  summary: Authenticate an individual
+  description: |
+    The OSIA IDUsage extended authentication
+    Change log:
+    - 1.0.0: Initial version
+  version: 1.0.0
+  title: The OSIA IDUsage extended authentication
   license:
     name: SIA
     url: "https://raw.githubusercontent.com/SecureIdentityAlliance/osia/master/LICENSE"
-  description: Authenticate an individual with the provided information
 servers:
-  - url: 'http://localhost:3000'
+   - url: https://rp.server.com
 paths:
   /authenticate:
-    parameters: []
     post:
-      summary: ''
-      operationId: post-authenticate
+      summary: 'Authenticate a person using one or more authentication factors'
+      operationId: authenticate
+      security:
+        - BearerAuth: [id.authenticate]
+      parameters:
+        - name: signature
+          in: header
+          description: JWS signature of the entire http body of the body header..signature
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              required:
+                - context
+                - consent
+                - authenticationFactors
+              properties:
+                context:
+                  $ref: '#/components/schemas/Context'
+                consent:
+                  $ref: '#/components/schemas/Consent'
+                authenticationFactors:
+                  type: array
+                  description: Authentication factors used for this authentication
+                  items:
+                    $ref: '#/components/schemas/AuthenticationFactor'
       responses:
-        '200':
+        200:
           description: OK
           content:
             application/json:
@@ -26,14 +61,9 @@ paths:
                   version:
                     type: string
                     description: Version of this response
-                  responseTime:
+                  responseDateTime:
                     type: string
                     description: ISO 8601
-                  transactionId:
-                    type: string
-                    minLength: 12
-                    maxLength: 50
-                    example: TXN123456789
                   purpose:
                     type: string
                     description: Same value as purpose in the request
@@ -49,7 +79,7 @@ paths:
                     type: boolean
                     default: false
                     description: Consent verification was performed or not.
-                  authResult:
+                  authenticationResult:
                     type: object
                     required:
                       - verified
@@ -66,12 +96,13 @@ paths:
                           Random Token either specific for this authentication
                           or specific for an individual & Relying party
                           combination.
-                        maxLength: 500
                         minLength: 12
+                        maxLength: 500
                       kycCredential:
                         $ref: '#/components/schemas/Credential'
                       kycUri:
                         type: string
+                        format: URI
                         description: Link pointing to the KYC data credential
                   errors:
                     type: array
@@ -97,267 +128,95 @@ paths:
                             correct the error.
                 required:
                   - version
-                  - transactionId
                   - purpose
                   - factorsVerified
                   - consentVerified
-                  - authResult
-              examples:
-                example-1: {}
-      description: To authenticate an individual
-      requestBody:
-        content:
-          application/json:
-            schema:
-              description: ''
-              type: object
-              x-examples:
-                example-1:
-                  context:
-                    id: id object
-                    transactionId: ABC123456723
-                    requestTime: '2016-07-16T19:20:30+5:30'
-                  consent:
-                    type: embedded / linked
-                    data: JWT
-                    schema: ''
-                    signUri: 'http://abc.json.sig'
-                    linkUri: 'http://abc.json'
-                  demographics:
-                    - attribute: name
-                      operator: equals
-                      value: John
-                      lang: ISO 639-1 language code
-                    - attribute: dob
-                      operator: equals
-                      value: John
-                      lang: ISO 639-1 language code
-                  biometrics:
-                    - specVersion: device spec version
-                      data:
-                        digitalId: >-
-                          Digital Id as described in this document signed
-                        deviceServiceVersion: device version
-                        bioType: Finger
-                        bioSubType: UNKNOWN
-                        purpose: Auth
-                        env: Target environment
-                        domainUri: URI of the auth server
-                        bioValue: >-
-                          Encrypted with session key and base64urlencoded
-                          biometric data
-                        transactionId: Unique transaction id
-                        timestamp: Current datetime in ISO format
-                        requestedScore: >-
-                          Floating point number to represent the minimum
-                          required score for the capture
-                        qualityScore: >-
-                          Floating point number representing the score for the
-                          current capture
-                      hash: >-
-                        sha256 in hex format in upper case (previous hash +
-                        sha256 hash of the current biometric ISO data before
-                        encryption)
-                      sessionKey: >-
-                        Session key used for encrypting bioValue, encrypted with
-                        system public key (dynamically selected based on the URI)
-                        and base64urlencoded
-                      thumbprint: >-
-                        SHA256 representation of the certificate (HEX encoded)
-                        that was used for encryption of session key. All texts
-                        to be treated as uppercase without any spaces or hyphens
-                    - specVersion: SBI spec version
-                      data:
-                        digitalId: >-
-                          Digital Id as described in this document signed using
-                          FTM key (SBI 2.0)
-                        deviceServiceVersion: device version
-                        bioType: Finger
-                        bioSubType: Left IndexFinger
-                        purpose: Auth
-                        env: Target environment
-                        domainUri: URI of the auth server
-                        bioValue: >-
-                          Encrypted with session key and base64urlencoded
-                          biometric data
-                        transactionId: Unique transaction id
-                        timestamp: Current datetime in ISO format
-                        requestedScore: >-
-                          Floating point number to represent the minimum
-                          required score for the capture
-                        qualityScore: >-
-                          Floating point number representing the score for the
-                          current capture
-                      hash: >-
-                        sha256 in hex format in upper case (previous hash +
-                        sha256 hash of the current biometric ISO data before
-                        encryption)
-                      sessionKey: >-
-                        Session key used for encrypting bioValue, encrypted with
-                        system public key (dynamically selected based on the URI)
-                        and base64urlencoded
-                      thumbprint: >-
-                        SHA256 representation of the certificate (HEX encoded)
-                        that was used for encryption of session key. All texts
-                        to be treated as uppercase without any spaces or hyphens
-                  authFactors:
-                    - factors: ''
-                      specVersion: ''
-                      data: []
-                    - factors: ''
-                      specVersion: ''
-                      data: []
-              properties:
-                context:
-                  type: object
-                  required:
-                    - id
-                    - transactionId
-                    - requestTime
-                  properties:
-                    id:
-                      type: string
-                      minLength: 1
-                      description: Identity used for authentication
-                    transactionId:
-                      type: string
-                      minLength: 12
-                      maxLength: 50
-                      description: >-
-                        The current transaction id or service request id as per
-                        the relying party
-                    requestTime:
-                      type: string
-                      description: Timestamp in ISO8601
-                      minLength: 12
-                      maxLength: 30
-                    purpose:
-                      type: string
-                      description: >-
-                        Purpose of the authentication request. Not mandatory but
-                        provides a way to ensure people know for what they are
-                        doing it
-                      minLength: 0
-                      maxLength: 256
-                    issuer:
-                      type: string
-                      description: >-
-                        Issuer of this ID. Its optional. Auth can be rejected in
-                        some scenarios if this is not present
-                      minLength: 0
-                      maxLength: 250
-                    type:
-                      type: string
-                      description: >-
-                        Type of the ID. Its optional and auth can not be
-                        rejected if the type is not present.
-                      minLength: 0
-                      maxLength: 150
-                consent:
-                  $ref: '#/components/schemas/Consent'
-                security:
-                  $ref: '#/components/schemas/Encryption'
-                demographics:
-                  type: array
-                  minItems: 1
-                  uniqueItems: true
-                  description: demographic information
-                  items:
-                    $ref: '#/components/schemas/DemoAttribute'
-                biometrics:
-                  type: array
-                  uniqueItems: true
-                  minItems: 1
-                  description: ISO 639-1 or ISO 639-2/
-                  items:
-                    $ref: '#/components/schemas/BiometricData'
-                authFactors:
-                  type: array
-                  uniqueItems: true
-                  minItems: 1
-                  description: Other auth factors that are supported.
-                  items:
-                    $ref: '#/components/schemas/AuthFactor_2'
-                '':
-                  type: string
-              required:
-                - context
-                - consent
-                - security
-                - demographics
-                - biometrics
-                - authFactors
-            examples:
-              Example:
-                value:
-                  context:
-                    id: 8284-8198-7235
-                    transactionId: TXN123456789
-                    requestTime: '2016-07-16T19:20:30+5:30'
-                  consent:
-                    type: linked
-                    schema: 'https://osia.org/schema/consent'
-                    signUri: 'https://osia.org/TXN123456789.sig'
-                    linkUri: 'https://osia.org/TXN123456789.data'
-                  demographics:
-                    - attributeName: name
-                      operator: '='
-                      value: John
-                      lang: eng
-                  biometrics:
-                    - specVersion: '1.0'
-                      data:
-                        captureDevice: string
-                        env: string
-                        deviceServiceVersion: '1.0'
-                        bioType: Finger
-                        bioSubType: Left IndexFinger
-                        purpose: Auth
-                        domainUri: 'http://osia.org'
-                        bioValue: >-
-                          yyy
-                        transactionId: TXN123456789
-                        timestamp: '2016-07-16T19:20:30+5:30'
-                        requestedScore: 65
-                        qualityScore: 90
-                      hash: string
-                      sessionKey: string
-                      thumbprint: string
-                  authFactors:
-                    - factor: string
-                      specVersion: string
-                      data:
-                        - {}
-      parameters:
-        - schema:
-            type: string
-          in: header
-          name: Signature
-          description: JWS signature of the entire http body of the body header..signature
+                  - authenticationResult
+        400:
+          description: 'Bad Request, Validation Errors, ...'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Operation not allowed
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
-    AuthFactor:
-      title: AuthFactor
+    Error:
       type: object
-      properties:
-        factor:
-          type: string
-        specVersion:
-          type: string
-        hash:
-          type: string
-        data:
-          type: array
-          items:
-            type: object
-        security:
-          $ref: '#/components/schemas/Encryption'
       required:
-        - factor
-        - specVersion
-        - data
-    AuthFactor_2:
-      title: AuthFactor
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+      additionalProperties: false
+
+    Context:
+      type: object
+      required:
+        - personId
+        - dateTime
+      properties:
+        personId:
+          type: string
+          minLength: 1
+          description: The identity of the person to authenticate
+        dateTime:
+          type: string
+          format: date
+          description: Timestamp in ISO8601
+          minLength: 12
+          maxLength: 30
+        purpose:
+          type: string
+          description: >-
+            Purpose of the authentication request. Not mandatory but
+            provides a way to ensure people know for what they are
+            doing it
+          minLength: 0
+          maxLength: 256
+        issuer:
+          type: string
+          description: >-
+            Issuer of the identity. Its optional. Authentication can be rejected in
+            some scenarios if this is not present
+          minLength: 0
+          maxLength: 250
+        type:
+          type: string
+          description: >-
+            Type of the ID. Its optional and auth can not be
+            rejected if the type is not present.
+          minLength: 0
+          maxLength: 150
+        environment:
+          type: string
+          minLength: 1
+        domainUri:
+          type: string
+          minLength: 1
+          format: uri
+    
+    AuthenticationFactor:
+      title: AuthenticationFactor
       type: object
       properties:
         factor:
@@ -365,204 +224,198 @@ components:
           minLength: 1
           maxLength: 256
           description: Name of the factor
-        specVersion:
-          type: string
-          minLength: 1
-          maxLength: 5
-          description: Adopted spec version for this factor
+        data:
+          oneOf:
+          - type: string
+          - $ref: '#/components/schemas/BiographicData'
+          - $ref: '#/components/schemas/BiometricData'
+          - $ref: '#/components/schemas/OtherData'
+          description: Data object as per the factors specification. Encrypted with session key and base64 encoded.
         hash:
           type: string
-          description: hash value of the data object before encryption
+          description: >-
+            sha256 in hex format in upper case (previous hash +
+            sha256 hash of the current biometric ISO data before
+            encryption)
           minLength: 1
           maxLength: 512
-        data:
-          type: array
-          description: Free data object as per the factors specification
-          items:
-            type: object
-        security:
-          $ref: '#/components/schemas/Encryption'
-      required:
-        - factor
-        - specVersion
-        - data
-    BiometricData:
-      title: BiometricFactor
-      type: object
-      properties:
-        specVersion:
-          type: string
-          minLength: 1
-          enum:
-            - '0.95'
-            - '1.0'
-        data:
-          type: object
-          description: >-
-            The entire data in this object is encrypted as a single blob and
-            attached here as a string - Refer the SBI Specification
-          properties:
-            captureDevice:
-              $ref: '#/components/schemas/CaptureDevice'
-            deviceServiceVersion:
-              type: string
-              minLength: 1
-              description: 'version of SBI (secure biometric interface) spec driver '
-            bioType:
-              type: string
-              minLength: 1
-              enum:
-                - Face
-                - Finger
-                - Iris
-                - Voice
-                - Palm
-              description: ''
-            bioSubType:
-              type: string
-              minLength: 1
-              enum:
-                - Left IndexFinger
-                - Left MiddleFinger
-                - Left RingFinger
-                - Left LittleFinger
-                - Left Thumb
-                - Right IndexFinger
-                - Right MiddleFinger
-                - Right RingFinger
-                - Right LittleFinger
-                - Right Thumb
-                - UNKNOWN
-                - Left
-                - Right
-            purpose:
-              type: string
-              minLength: 1
-              enum:
-                - Auth
-                - KYC
-                - Registration
-              maxLength: 144
-              description: >-
-                simple string to explain the purpose of the auth. This will be
-                notified to the user
-            env:
-              type: string
-              minLength: 1
-            domainUri:
-              type: string
-              minLength: 1
-              format: uri
-            bioValue:
-              type: string
-              minLength: 1
-            requestedScore:
-              type: number
-              minimum: 0
-              maximum: 100
-            transactionId:
-              type: string
-              minLength: 12
-              maxLength: 50
-              example: ABC123456789
-            timestamp:
-              type: string
-              minLength: 20
-              example: '2016-07-16T19:20:30+5:30'
-            qualityScore:
-              type: number
-              minimum: 0
-              maximum: 100
-          required:
-            - captureDevice
-            - bioType
-            - bioSubType
-            - bioValue
-            - transactionId
-            - timestamp
-        hash:
-          type: string
-          minLength: 1
         sessionKey:
           type: string
+          description: >-
+            Session key used for encrypting bioValue, encrypted with
+            the system public key (dynamically selected based on the URI)
+            and base64 encoded
           minLength: 1
         thumbprint:
           type: string
           minLength: 1
+          description: >-
+            SHA256 representation of the certificate (HEX encoded)
+            that was used for encryption of session key. All texts
+            to be treated as uppercase without any spaces or hyphens
+        algorithm:
+          type: string
+
       required:
-        - specVersion
-        - hash
-        - sessionKey
-        - thumbprint
-      x-examples: null
-      example-1:
-        env: Target environment
-        purpose: Registration
-        specVersion: Expected SBI spec version
-        timeout: Timeout for registration capture
-        captureTime: Time of capture request in ISO format
-        transactionId: Transaction Id for the current capture
-        bio:
-          - type: Type of the biometric data
-            count: 'Finger/Iris count, in case of face max is set to 1'
-            bioSubType:
-              - Array of subtypes
-            exception:
-              - Finger or Iris to be excluded
-            requestedScore: >-
-              Expected quality score that should match to complete a successful
-              capture.
-            serialNo: Printed Serial Number of the device
-            deviceSubId: Specific device Id
-            previousHash: Hash of the previous block
-      examples:
-        - specVersion: '0.95'
-          data:
-            captureDevice:
-              serialNo: string
-              make: string
-              model: string
-              type: Finger
-              deviceSubType: string
-              deviceProvider: string
-              deviceProviderId: string
-              dateTime: string
-            deviceServiceVersion: string
-            bioType: Face
-            bioSubType: Left IndexFinger
-            purpose: Auth
-            env: string
-            domainUri: 'http://example.com'
-            bioValue: string
-            requestedScore: 0
-            transactionId: ABC123456789
-            timestamp: '2016-07-16T19:20:30+5:30'
-            qualityScore: 0
-          hash: string
-          sessionKey: string
-          thumbprint: string
+        - factor
+        - data
+
+    BiographicExpression:
+      type: object
+      required:
+        - attributeName
+        - operator
+        - value
+      properties:
+        attributeName:
+          type: string
+        operator:
+          type: string
+          enum: ['<', '>', '=', '>=', '<=']
+        value:
+          oneOf:
+          - type: string
+          - type: integer
+          - type: number
+          - type: boolean
+      additionalProperties: false
+
+    OtherData:
+      type: object
+      description: Authentication data for other factors
+      additionalProperties: true
+
+    BiographicData:
+      type: array
+      items:
+        $ref: '#/components/schemas/BiographicExpression'
+
+    BiometricData:
+      type: object
+      required:
+        - biometricType
+      properties:
+        biometricType:
+          $ref: '#/components/schemas/BiometricType'
+        biometricSubType:
+          $ref: '#/components/schemas/BiometricSubType'
+        instance:
+          type: string
+          description: Used to separate two distincts biometric items of the same type and subtype
+        image:
+          type: string
+          format: byte
+          description: Base64-encoded image
+        imageRef:
+          type: string
+          format: uri
+          description: URI to an image
+          example: "http://imageserver.com/image?id=00003"
+        captureDate:
+          type: string
+          format: date
+          example: "2019-05-21"
+        captureDevice:
+          description: Identification of the device used to capture the biometric
+          oneOf:
+          - type: string
+          - $ref: '#/components/schemas/CaptureDevice'
+        width:
+          type: integer
+          description: the width of the image
+        height:
+          type: integer
+          description: the height of the image
+        bitdepth:
+          type: integer
+        resolution:
+          type: integer
+          description: the image resolution (in DPI)
+        compression:
+          $ref: '#/components/schemas/CompressionType'
+        metadata:
+          type: string
+          description: An optional string used to convey information vendor-specific
+        comment:
+          type: string
+          description: A comment about the biometric data
+      additionalProperties: false
+  
+    BiometricType:
+      type: string
+      enum:
+        - FACE
+        - FINGER
+        - IRIS
+        - SIGNATURE
+        - UNKNOWN
+        
+    BiometricSubType:
+      type: string
+      enum:
+        - UNKNOWN
+        - RIGHT_THUMB
+        - RIGHT_INDEX
+        - RIGHT_MIDDLE
+        - RIGHT_RING
+        - RIGHT_LITTLE
+        - LEFT_THUMB
+        - LEFT_INDEX
+        - LEFT_MIDDLE
+        - LEFT_RING
+        - LEFT_LITTLE
+        - PLAIN_RIGHT_FOUR_FINGERS
+        - PLAIN_LEFT_FOUR_FINGERS
+        - PLAIN_THUMBS
+        
+        - UNKNOWN_PALM
+        - RIGHT_FULL_PALM
+        - RIGHT_WRITERS_PALM
+        - LEFT_FULL_PALM
+        - LEFT_WRITERS_PALM
+        - RIGHT_LOWER_PALM
+        - RIGHT_UPPER_PALM
+        - LEFT_LOWER_PALM
+        - LEFT_UPPER_PALM
+        - RIGHT_OTHER
+        - LEFT_OTHER
+        - RIGHT_INTERDIGITAL
+        - RIGHT_THENAR
+        - LEFT_INTERDIGITAL
+        - LEFT_THENAR
+        - LEFT_HYPOTHENAR
+        
+        - RIGHT_INDEX_AND_MIDDLE
+        - RIGHT_MIDDLE_AND_RING
+        - RIGHT_RING_AND_LITTLE
+        - LEFT_INDEX_AND_MIDDLE
+        - LEFT_MIDDLE_AND_RING
+        - LEFT_RING_AND_LITTLE
+        - RIGHT_INDEX_AND_LEFT_INDEX
+        - RIGHT_INDEX_AND_MIDDLE_AND_RING
+        - RIGHT_MIDDLE_AND_RING_AND_LITTLE
+        - LEFT_INDEX_AND_MIDDLE_AND_RING
+        - LEFT_MIDDLE_AND_RING_AND_LITTLE
+        
+        - EYE_UNDEF
+        - EYE_RIGHT
+        - EYE_LEFT
+        
+        - PORTRAIT
+        - LEFT_PROFILE
+        - RIGHT_PROFILE
+    CompressionType:
+      type: string
+      enum: [NONE, WSQ, JPEG, JPEG2000, PNG]
+
     CaptureDevice:
       description: Digital footprint of the capture device
       type: object
-      x-examples:
-        example-1:
-          serialNo: Serial number
-          make: Make of the device
-          model: Model of the device
-          type: Type of the biometric device
-          deviceSubType: Subtypes of the biometric device
-          deviceProvider: Device provider name
-          deviceProviderId: Device provider id
-          dateTime: Current datetime in ISO format
       properties:
-        serialNo:
+        serialNumber:
           type: string
-          description: >-
-            Serial no of the device, same as whats printed on the device. In
-            case of integrated pls ensure the it can be seen in about device or
-            similar such features. Alpha numeric
           minLength: 0
-          maxLength: 12
+          maxLength: 36
         make:
           type: string
           minLength: 1
@@ -575,24 +428,20 @@ components:
           description: Model of the device
         type:
           type: string
-          minLength: 1
           enum:
-            - Finger
-            - Iris
-            - Face
-          maxLength: 50
+            - FNGER
+            - IRIS
+            - FACE
           description: Type of the device
         deviceSubType:
           type: string
-          minLength: 1
           enum:
-            - Slap
-            - Single
-            - Touchless
-            - Double
-            - Full Frontal
-          maxLength: 50
-          description: Additional mode details of device type. Its a enum
+            - SLAP
+            - SINGLE
+            - TOUCHLESS
+            - DOUBLE
+            - FULL_FRONTAL
+          description: Additional details of device type
         deviceProvider:
           type: string
           minLength: 1
@@ -609,11 +458,12 @@ components:
           description: 'ISO Timestamp of the device '
           format: date-time
       required:
-        - serialNo
+        - serialNumber
         - make
         - model
         - type
         - dateTime
+        
     Consent:
       title: Consent
       type: object
@@ -621,31 +471,28 @@ components:
       properties:
         type:
           type: string
-          minLength: 1
           enum:
-            - embedded
-            - linked
-            - no-consent
-          example: linked
-          maxLength: 50
+            - LINKED
+            - EMBEDDED
+            - NO_CONSENT
           description: Consent type. Limited the enum values
         data:
           type: string
           minLength: 1
-          description: embedded data in jwt format
           maxLength: 256
+          description: embedded data in jwt format
         schema:
           type: string
-          format: uri-reference
+          format: uri
           minLength: 1
           maxLength: 256
           description: Schema for the consent
         signUri:
           type: string
-          minLength: 1
           format: uri
-          description: signature url. no data of the consent
+          minLength: 1
           maxLength: 256
+          description: signature url. no data of the consent
         linkUri:
           type: string
           minLength: 1
@@ -654,24 +501,11 @@ components:
           maxLength: 256
       required:
         - type
+        
     Credential:
       title: Credential
       description: Credential
       type: object
-      x-examples:
-        example-1:
-          issuedTo: mpartner-default-print
-          protectedAttributes: []
-          issuanceDate: '2021-01-20T04:38:41.045Z'
-          credentialSubject:
-            name: james
-            gender: male
-          id: 'http://osia.org/credentials/9178c6ed-6c3d-4be4-9eef-7668ca236c21'
-          type:
-            - VerifiableCredential
-            - OSIAVerifiableCredential
-          consent: ''
-          issuer: 'https://osia.org/issuers/'
       properties:
         issuer:
           type: string
@@ -793,41 +627,3 @@ components:
         - type
         - consent
         - proof
-    DemoAttribute:
-      title: Demo
-      type: object
-      properties:
-        atributeName:
-          type: string
-          description: 'Name of the atribute. eg name, firstname'
-        value:
-          type: string
-          description: Value for the demographic data
-        language:
-          type: string
-          description: Language of the value ISO 639-1
-      required:
-        - atributeName
-        - value
-    Encryption:
-      title: Encryption
-      type: object
-      properties:
-        sessionKey:
-          type: string
-        thumbprint:
-          type: string
-        algorithm:
-          type: string
-      required:
-        - sessionKey
-        - thumbprint
-      examples:
-        - sessionKey: string
-          thumbprint: string
-          algorithm: string
-  securitySchemes:
-    Authorization:
-      type: openIdConnect
-      openIdConnectUrl: 'https://iam.osia.org/auth/openid-configuration'
-  responses: {}

--- a/src/doc/yaml/authenticate.yaml
+++ b/src/doc/yaml/authenticate.yaml
@@ -1,0 +1,833 @@
+openapi: 3.1.0
+info:
+  title: authenticate
+  version: '1.0'
+  summary: Authenticate an individual
+  license:
+    name: SIA
+    url: "https://raw.githubusercontent.com/SecureIdentityAlliance/osia/master/LICENSE"
+  description: Authenticate an individual with the provided information
+servers:
+  - url: 'http://localhost:3000'
+paths:
+  /authenticate:
+    parameters: []
+    post:
+      summary: ''
+      operationId: post-authenticate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: Version of this response
+                  responseTime:
+                    type: string
+                    description: ISO 8601
+                  transactionId:
+                    type: string
+                    minLength: 12
+                    maxLength: 50
+                    example: TXN123456789
+                  purpose:
+                    type: string
+                    description: Same value as purpose in the request
+                  factorsVerified:
+                    type: array
+                    description: >-
+                      What are all the factors we verified. So in case the
+                      relying party needs a mandatory factor he can check and
+                      ensure if the authentication contained such a factor.
+                    items:
+                      type: string
+                  consentVerified:
+                    type: boolean
+                    default: false
+                    description: Consent verification was performed or not.
+                  authResult:
+                    type: object
+                    required:
+                      - verified
+                      - tokenId
+                    description: Result of the authentication
+                    properties:
+                      verified:
+                        type: boolean
+                        default: false
+                        description: result of the authentication. A simple boolean
+                      tokenId:
+                        type: string
+                        description: >-
+                          Random Token either specific for this authentication
+                          or specific for an individual & Relying party
+                          combination.
+                        maxLength: 500
+                        minLength: 12
+                      kycCredential:
+                        $ref: '#/components/schemas/Credential'
+                      kycUri:
+                        type: string
+                        description: Link pointing to the KYC data credential
+                  errors:
+                    type: array
+                    description: >-
+                      Error code array. Messages for the repsective errors has
+                      to be transalated as 
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                          description: 'unique error code '
+                        message:
+                          type: string
+                          description: description of the error message
+                        language:
+                          type: string
+                          description: ISO 639-2
+                        action:
+                          type: string
+                          description: >-
+                            action that we want the user to make in order to
+                            correct the error.
+                required:
+                  - version
+                  - transactionId
+                  - purpose
+                  - factorsVerified
+                  - consentVerified
+                  - authResult
+              examples:
+                example-1: {}
+      description: To authenticate an individual
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              x-examples:
+                example-1:
+                  context:
+                    id: id object
+                    transactionId: ABC123456723
+                    requestTime: '2016-07-16T19:20:30+5:30'
+                  consent:
+                    type: embedded / linked
+                    data: JWT
+                    schema: ''
+                    signUri: 'http://abc.json.sig'
+                    linkUri: 'http://abc.json'
+                  demographics:
+                    - attribute: name
+                      operator: equals
+                      value: John
+                      lang: ISO 639-1 language code
+                    - attribute: dob
+                      operator: equals
+                      value: John
+                      lang: ISO 639-1 language code
+                  biometrics:
+                    - specVersion: device spec version
+                      data:
+                        digitalId: >-
+                          Digital Id as described in this document signed
+                        deviceServiceVersion: device version
+                        bioType: Finger
+                        bioSubType: UNKNOWN
+                        purpose: Auth
+                        env: Target environment
+                        domainUri: URI of the auth server
+                        bioValue: >-
+                          Encrypted with session key and base64urlencoded
+                          biometric data
+                        transactionId: Unique transaction id
+                        timestamp: Current datetime in ISO format
+                        requestedScore: >-
+                          Floating point number to represent the minimum
+                          required score for the capture
+                        qualityScore: >-
+                          Floating point number representing the score for the
+                          current capture
+                      hash: >-
+                        sha256 in hex format in upper case (previous hash +
+                        sha256 hash of the current biometric ISO data before
+                        encryption)
+                      sessionKey: >-
+                        Session key used for encrypting bioValue, encrypted with
+                        system public key (dynamically selected based on the URI)
+                        and base64urlencoded
+                      thumbprint: >-
+                        SHA256 representation of the certificate (HEX encoded)
+                        that was used for encryption of session key. All texts
+                        to be treated as uppercase without any spaces or hyphens
+                    - specVersion: SBI spec version
+                      data:
+                        digitalId: >-
+                          Digital Id as described in this document signed using
+                          FTM key (SBI 2.0)
+                        deviceServiceVersion: device version
+                        bioType: Finger
+                        bioSubType: Left IndexFinger
+                        purpose: Auth
+                        env: Target environment
+                        domainUri: URI of the auth server
+                        bioValue: >-
+                          Encrypted with session key and base64urlencoded
+                          biometric data
+                        transactionId: Unique transaction id
+                        timestamp: Current datetime in ISO format
+                        requestedScore: >-
+                          Floating point number to represent the minimum
+                          required score for the capture
+                        qualityScore: >-
+                          Floating point number representing the score for the
+                          current capture
+                      hash: >-
+                        sha256 in hex format in upper case (previous hash +
+                        sha256 hash of the current biometric ISO data before
+                        encryption)
+                      sessionKey: >-
+                        Session key used for encrypting bioValue, encrypted with
+                        system public key (dynamically selected based on the URI)
+                        and base64urlencoded
+                      thumbprint: >-
+                        SHA256 representation of the certificate (HEX encoded)
+                        that was used for encryption of session key. All texts
+                        to be treated as uppercase without any spaces or hyphens
+                  authFactors:
+                    - factors: ''
+                      specVersion: ''
+                      data: []
+                    - factors: ''
+                      specVersion: ''
+                      data: []
+              properties:
+                context:
+                  type: object
+                  required:
+                    - id
+                    - transactionId
+                    - requestTime
+                  properties:
+                    id:
+                      type: string
+                      minLength: 1
+                      description: Identity used for authentication
+                    transactionId:
+                      type: string
+                      minLength: 12
+                      maxLength: 50
+                      description: >-
+                        The current transaction id or service request id as per
+                        the relying party
+                    requestTime:
+                      type: string
+                      description: Timestamp in ISO8601
+                      minLength: 12
+                      maxLength: 30
+                    purpose:
+                      type: string
+                      description: >-
+                        Purpose of the authentication request. Not mandatory but
+                        provides a way to ensure people know for what they are
+                        doing it
+                      minLength: 0
+                      maxLength: 256
+                    issuer:
+                      type: string
+                      description: >-
+                        Issuer of this ID. Its optional. Auth can be rejected in
+                        some scenarios if this is not present
+                      minLength: 0
+                      maxLength: 250
+                    type:
+                      type: string
+                      description: >-
+                        Type of the ID. Its optional and auth can not be
+                        rejected if the type is not present.
+                      minLength: 0
+                      maxLength: 150
+                consent:
+                  $ref: '#/components/schemas/Consent'
+                security:
+                  $ref: '#/components/schemas/Encryption'
+                demographics:
+                  type: array
+                  minItems: 1
+                  uniqueItems: true
+                  description: demographic information
+                  items:
+                    $ref: '#/components/schemas/DemoAttribute'
+                biometrics:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  description: ISO 639-1 or ISO 639-2/
+                  items:
+                    $ref: '#/components/schemas/BiometricData'
+                authFactors:
+                  type: array
+                  uniqueItems: true
+                  minItems: 1
+                  description: Other auth factors that are supported.
+                  items:
+                    $ref: '#/components/schemas/AuthFactor_2'
+                '':
+                  type: string
+              required:
+                - context
+                - consent
+                - security
+                - demographics
+                - biometrics
+                - authFactors
+            examples:
+              Example:
+                value:
+                  context:
+                    id: 8284-8198-7235
+                    transactionId: TXN123456789
+                    requestTime: '2016-07-16T19:20:30+5:30'
+                  consent:
+                    type: linked
+                    schema: 'https://osia.org/schema/consent'
+                    signUri: 'https://osia.org/TXN123456789.sig'
+                    linkUri: 'https://osia.org/TXN123456789.data'
+                  demographics:
+                    - attributeName: name
+                      operator: '='
+                      value: John
+                      lang: eng
+                  biometrics:
+                    - specVersion: '1.0'
+                      data:
+                        captureDevice: string
+                        env: string
+                        deviceServiceVersion: '1.0'
+                        bioType: Finger
+                        bioSubType: Left IndexFinger
+                        purpose: Auth
+                        domainUri: 'http://osia.org'
+                        bioValue: >-
+                          yyy
+                        transactionId: TXN123456789
+                        timestamp: '2016-07-16T19:20:30+5:30'
+                        requestedScore: 65
+                        qualityScore: 90
+                      hash: string
+                      sessionKey: string
+                      thumbprint: string
+                  authFactors:
+                    - factor: string
+                      specVersion: string
+                      data:
+                        - {}
+      parameters:
+        - schema:
+            type: string
+          in: header
+          name: Signature
+          description: JWS signature of the entire http body of the body header..signature
+components:
+  schemas:
+    AuthFactor:
+      title: AuthFactor
+      type: object
+      properties:
+        factor:
+          type: string
+        specVersion:
+          type: string
+        hash:
+          type: string
+        data:
+          type: array
+          items:
+            type: object
+        security:
+          $ref: '#/components/schemas/Encryption'
+      required:
+        - factor
+        - specVersion
+        - data
+    AuthFactor_2:
+      title: AuthFactor
+      type: object
+      properties:
+        factor:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Name of the factor
+        specVersion:
+          type: string
+          minLength: 1
+          maxLength: 5
+          description: Adopted spec version for this factor
+        hash:
+          type: string
+          description: hash value of the data object before encryption
+          minLength: 1
+          maxLength: 512
+        data:
+          type: array
+          description: Free data object as per the factors specification
+          items:
+            type: object
+        security:
+          $ref: '#/components/schemas/Encryption'
+      required:
+        - factor
+        - specVersion
+        - data
+    BiometricData:
+      title: BiometricFactor
+      type: object
+      properties:
+        specVersion:
+          type: string
+          minLength: 1
+          enum:
+            - '0.95'
+            - '1.0'
+        data:
+          type: object
+          description: >-
+            The entire data in this object is encrypted as a single blob and
+            attached here as a string - Refer the SBI Specification
+          properties:
+            captureDevice:
+              $ref: '#/components/schemas/CaptureDevice'
+            deviceServiceVersion:
+              type: string
+              minLength: 1
+              description: 'version of SBI (secure biometric interface) spec driver '
+            bioType:
+              type: string
+              minLength: 1
+              enum:
+                - Face
+                - Finger
+                - Iris
+                - Voice
+                - Palm
+              description: ''
+            bioSubType:
+              type: string
+              minLength: 1
+              enum:
+                - Left IndexFinger
+                - Left MiddleFinger
+                - Left RingFinger
+                - Left LittleFinger
+                - Left Thumb
+                - Right IndexFinger
+                - Right MiddleFinger
+                - Right RingFinger
+                - Right LittleFinger
+                - Right Thumb
+                - UNKNOWN
+                - Left
+                - Right
+            purpose:
+              type: string
+              minLength: 1
+              enum:
+                - Auth
+                - KYC
+                - Registration
+              maxLength: 144
+              description: >-
+                simple string to explain the purpose of the auth. This will be
+                notified to the user
+            env:
+              type: string
+              minLength: 1
+            domainUri:
+              type: string
+              minLength: 1
+              format: uri
+            bioValue:
+              type: string
+              minLength: 1
+            requestedScore:
+              type: number
+              minimum: 0
+              maximum: 100
+            transactionId:
+              type: string
+              minLength: 12
+              maxLength: 50
+              example: ABC123456789
+            timestamp:
+              type: string
+              minLength: 20
+              example: '2016-07-16T19:20:30+5:30'
+            qualityScore:
+              type: number
+              minimum: 0
+              maximum: 100
+          required:
+            - captureDevice
+            - bioType
+            - bioSubType
+            - bioValue
+            - transactionId
+            - timestamp
+        hash:
+          type: string
+          minLength: 1
+        sessionKey:
+          type: string
+          minLength: 1
+        thumbprint:
+          type: string
+          minLength: 1
+      required:
+        - specVersion
+        - hash
+        - sessionKey
+        - thumbprint
+      x-examples: null
+      example-1:
+        env: Target environment
+        purpose: Registration
+        specVersion: Expected SBI spec version
+        timeout: Timeout for registration capture
+        captureTime: Time of capture request in ISO format
+        transactionId: Transaction Id for the current capture
+        bio:
+          - type: Type of the biometric data
+            count: 'Finger/Iris count, in case of face max is set to 1'
+            bioSubType:
+              - Array of subtypes
+            exception:
+              - Finger or Iris to be excluded
+            requestedScore: >-
+              Expected quality score that should match to complete a successful
+              capture.
+            serialNo: Printed Serial Number of the device
+            deviceSubId: Specific device Id
+            previousHash: Hash of the previous block
+      examples:
+        - specVersion: '0.95'
+          data:
+            captureDevice:
+              serialNo: string
+              make: string
+              model: string
+              type: Finger
+              deviceSubType: string
+              deviceProvider: string
+              deviceProviderId: string
+              dateTime: string
+            deviceServiceVersion: string
+            bioType: Face
+            bioSubType: Left IndexFinger
+            purpose: Auth
+            env: string
+            domainUri: 'http://example.com'
+            bioValue: string
+            requestedScore: 0
+            transactionId: ABC123456789
+            timestamp: '2016-07-16T19:20:30+5:30'
+            qualityScore: 0
+          hash: string
+          sessionKey: string
+          thumbprint: string
+    CaptureDevice:
+      description: Digital footprint of the capture device
+      type: object
+      x-examples:
+        example-1:
+          serialNo: Serial number
+          make: Make of the device
+          model: Model of the device
+          type: Type of the biometric device
+          deviceSubType: Subtypes of the biometric device
+          deviceProvider: Device provider name
+          deviceProviderId: Device provider id
+          dateTime: Current datetime in ISO format
+      properties:
+        serialNo:
+          type: string
+          description: >-
+            Serial no of the device, same as whats printed on the device. In
+            case of integrated pls ensure the it can be seen in about device or
+            similar such features. Alpha numeric
+          minLength: 0
+          maxLength: 12
+        make:
+          type: string
+          minLength: 1
+          maxLength: 50
+          description: Make of the device
+        model:
+          type: string
+          minLength: 1
+          maxLength: 50
+          description: Model of the device
+        type:
+          type: string
+          minLength: 1
+          enum:
+            - Finger
+            - Iris
+            - Face
+          maxLength: 50
+          description: Type of the device
+        deviceSubType:
+          type: string
+          minLength: 1
+          enum:
+            - Slap
+            - Single
+            - Touchless
+            - Double
+            - Full Frontal
+          maxLength: 50
+          description: Additional mode details of device type. Its a enum
+        deviceProvider:
+          type: string
+          minLength: 1
+          description: Provider name as per the certifcation
+          maxLength: 256
+        deviceProviderId:
+          type: string
+          minLength: 1
+          description: Unique provider id assigned by the certifier
+          maxLength: 50
+        dateTime:
+          type: string
+          minLength: 1
+          description: 'ISO Timestamp of the device '
+          format: date-time
+      required:
+        - serialNo
+        - make
+        - model
+        - type
+        - dateTime
+    Consent:
+      title: Consent
+      type: object
+      description: ''
+      properties:
+        type:
+          type: string
+          minLength: 1
+          enum:
+            - embedded
+            - linked
+            - no-consent
+          example: linked
+          maxLength: 50
+          description: Consent type. Limited the enum values
+        data:
+          type: string
+          minLength: 1
+          description: embedded data in jwt format
+          maxLength: 256
+        schema:
+          type: string
+          format: uri-reference
+          minLength: 1
+          maxLength: 256
+          description: Schema for the consent
+        signUri:
+          type: string
+          minLength: 1
+          format: uri
+          description: signature url. no data of the consent
+          maxLength: 256
+        linkUri:
+          type: string
+          minLength: 1
+          format: uri
+          description: unique link to the content of the consent
+          maxLength: 256
+      required:
+        - type
+    Credential:
+      title: Credential
+      description: Credential
+      type: object
+      x-examples:
+        example-1:
+          issuedTo: mpartner-default-print
+          protectedAttributes: []
+          issuanceDate: '2021-01-20T04:38:41.045Z'
+          credentialSubject:
+            name: james
+            gender: male
+          id: 'http://osia.org/credentials/9178c6ed-6c3d-4be4-9eef-7668ca236c21'
+          type:
+            - VerifiableCredential
+            - OSIAVerifiableCredential
+          consent: ''
+          issuer: 'https://osia.org/issuers/'
+      properties:
+        issuer:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Who has issued this credential.
+        id:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: ID of the credential
+        issuedTo:
+          type: string
+          minLength: 1
+          description: to whom the id is issued to
+          maxLength: 256
+        issuanceDate:
+          type: string
+          minLength: 1
+          format: date-time
+        protectedAttributes:
+          type: array
+          description: Array of atributes that are available in protected form (encrypted).
+          items:
+            type: string
+        credentialSubject:
+          type: object
+          required:
+            - id
+            - idOf
+          description: Subject information for the credential
+          properties:
+            id:
+              type: string
+              minLength: 10
+              maxLength: 50
+              description: id of subject
+            idOf:
+              type: array
+              description: Array of information about the subject
+              items:
+                type: object
+                properties:
+                  attributeName:
+                    type: string
+                    description: Name of the atribute
+                    minLength: 1
+                    maxLength: 256
+                  value:
+                    type: string
+                    minLength: 0
+                    maxLength: 1024
+                    description: >-
+                      Value for the given atribute. Note: It could be encrypted
+                      if the atribute name is part of the protected array.
+                  language:
+                    type: string
+                    minLength: 2
+                    maxLength: 3
+                    description: >-
+                      language in ISO 639-1 format. USe 639-2 only when the code
+                      is not available in 639-1
+        type:
+          type: array
+          description: Array of strings indicating the type of the credential
+          minItems: 1
+          maxItems: 20
+          items:
+            type: string
+            example: '["VerifiableCredential", "AlumniCredential"]'
+            minLength: 1
+            maxLength: 50
+        consent:
+          $ref: '#/components/schemas/Consent'
+        proof:
+          type: object
+          required:
+            - type
+            - created
+            - proofPurpose
+            - verificationMethod
+            - jws
+          description: Credential proof
+          properties:
+            type:
+              type: string
+              minLength: 1
+              maxLength: 10
+              description: Type of the proof
+              enum:
+                - RsaSignature2018
+                - ED25519
+            created:
+              type: string
+              format: date-time
+              description: What was it created
+            proofPurpose:
+              type: string
+              minLength: 0
+              maxLength: 256
+              description: What is the purpose of this proof
+            verificationMethod:
+              type: string
+              minLength: 1
+              maxLength: 256
+              description: URL to the keys
+            jws:
+              type: string
+              description: JWS of the format header..signature
+              minLength: 0
+              maxLength: 10000
+      required:
+        - issuer
+        - id
+        - issuedTo
+        - issuanceDate
+        - protectedAttributes
+        - credentialSubject
+        - type
+        - consent
+        - proof
+    DemoAttribute:
+      title: Demo
+      type: object
+      properties:
+        atributeName:
+          type: string
+          description: 'Name of the atribute. eg name, firstname'
+        value:
+          type: string
+          description: Value for the demographic data
+        language:
+          type: string
+          description: Language of the value ISO 639-1
+      required:
+        - atributeName
+        - value
+    Encryption:
+      title: Encryption
+      type: object
+      properties:
+        sessionKey:
+          type: string
+        thumbprint:
+          type: string
+        algorithm:
+          type: string
+      required:
+        - sessionKey
+        - thumbprint
+      examples:
+        - sessionKey: string
+          thumbprint: string
+          algorithm: string
+  securitySchemes:
+    Authorization:
+      type: openIdConnect
+      openIdConnectUrl: 'https://iam.osia.org/auth/openid-configuration'
+  responses: {}


### PR DESCRIPTION
This pull request contains an OpenAPI specification to propose an extension of the authentication service exposed to relying parties. Compared to the existing OSIA service ([verify identity](https://osia.readthedocs.io/en/latest/05%20-%20interfaces.html#relying-party-api)), this new service brings:
- the ability to use more authentication factors
- additional security features: 
  - authentication and response can be bound to one transaction,
  - the consent of the citizen/user can be provided,
  - authentication factor data can be signed and encrypted,
  - request can be checked for integrity.

This proposition was first discussed outside the usual OSIA workgroup with other organizations, and was then updated to be more consistent with the existing OSIA services.
This is not yet perfect and the YAML is not yet integrated in the OSIA PDF documentation but it is now open for comments from the community.
