### PR TITLE
Fix some inconsistency issues

### DIFF
--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -9,7 +9,8 @@ info:
     Change log:
 
     - 1.5.0:
-      - Add service to update only the galleries of an encounter    
+      - Add service to update only the galleries of an encounter
+      - Change date to date-time
     - 1.4.0:
       - Add an entity (ExtendablePersonIds) used in the response of create & update operations
       - Make 202 response more standard: returns an object with at least a taskId, additional properties allowed
@@ -44,7 +45,7 @@ info:
       - Add service 'readAllEncounters'
     - 1.0.0: Initial version
 
-  version: 1.4.0
+  version: 1.5.0
   title: OSIA ABIS Interface
   license:
     name: SIA
@@ -2286,8 +2287,8 @@ components:
           example: "http://imageserver.com/image?id=00003"
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -14,6 +14,7 @@ info:
       - Mark the encounterId as readOnly, add it to biometricData
       - Add mimeType, template, templateFormat to biometricData
       - rename scoreList to scores in identification result
+      - Do not mix fixed properties and additional properties, use a subobject for the additional properties
     - 1.4.0:
       - Add an entity (ExtendablePersonIds) used in the response of create & update operations
       - Make 202 response more standard: returns an object with at least a taskId, additional properties allowed
@@ -2381,12 +2382,6 @@ components:
         algorithm:
           type: string
       additionalProperties: false
-    TemplateFormat:
-      type: string
-      description: |
-        Format of the template.
-        One of ISO_19794_2, ISO_19794_2_NS, ISO_19794_2_CS, ISO_19794_2_2011, ANSI_378_2009 or ANSI_378.
-        Can be extended to include additional proprietary template format
     QualityFormat:
       type: string
       description: |
@@ -2523,7 +2518,10 @@ components:
             the relating biometric
           items:
             $ref: '#/components/schemas/ScoreDetail'
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
     ScoreDetail:
       description: |
         Scoring information calculated after a biometric search.
@@ -2550,7 +2548,10 @@ components:
         instance:
           type: string
           description: Used to separate two distincts biometric items of the same type and subtype
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
     PersonIds:
       type: object
       required:
@@ -2578,7 +2579,10 @@ components:
           type: string
         encounterId:
           type: string
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
     TaskId:
       description: |
         Information about the asynchronous task. Only the taskId is mandatory but
@@ -2591,4 +2595,7 @@ components:
         taskId:
           type: string
           example: '"123e4567-e89b-12d3-a456-426655440000"'
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -2313,7 +2313,7 @@ components:
           type: integer
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the image. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -11,6 +11,8 @@ info:
     - 1.5.0:
       - Add service to update only the galleries of an encounter
       - Change date to date-time
+      - Mark the encounterId as readOnly, add it to biometricData
+      - Add mimeType, template, templateFormat to biometricData
     - 1.4.0:
       - Add an entity (ExtendablePersonIds) used in the response of create & update operations
       - Make 202 response more standard: returns an object with at least a taskId, additional properties allowed
@@ -2223,11 +2225,13 @@ components:
       type: object
       required:
         - status
+        - encounterId
         - encounterType
         - biometricData
       properties:
         encounterId:
           type: string
+          readOnly: true
         status:
           type: string
           enum: [ACTIVE, INACTIVE]
@@ -2276,6 +2280,9 @@ components:
         instance:
           type: string
           description: Used to separate two distincts biometric items of the same type and subtype
+        encounterId:
+          type: string
+          readOnly: true
         image:
           type: string
           format: byte
@@ -2302,6 +2309,9 @@ components:
           description: the height of the image
         bitdepth:
           type: integer
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)
@@ -2318,7 +2328,19 @@ components:
         comment:
           type: string
           description: A comment about the biometric data
+        template:
+          type: string
+          format: byte
+          description: Base64-encoded template
+        templateFormat:
+          $ref: '#/components/schemas/TemplateFormat'
       additionalProperties: false
+    TemplateFormat:
+      type: string
+      description: |
+        Format of the template.
+        One of ISO_19794_2, ISO_19794_2_NS, ISO_19794_2_CS, ISO_19794_2_2011, ANSI_378_2009 or ANSI_378.
+        Can be extended to include additional proprietary template format
     MissingType:
       type: object
       properties:

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -13,6 +13,7 @@ info:
       - Change date to date-time
       - Mark the encounterId as readOnly, add it to biometricData
       - Add mimeType, template, templateFormat to biometricData
+      - rename scoreList to scores in identification result
     - 1.4.0:
       - Add an entity (ExtendablePersonIds) used in the response of create & update operations
       - Make 202 response more standard: returns an object with at least a taskId, additional properties allowed
@@ -2515,7 +2516,7 @@ components:
             the score of the candidate in relation to other candidates for
             the same biometric identification operation
           example: 3500
-        scoreList:
+        scores:
           type: array
           description: >-
             a list of comparison score(s) and optionally the type and subtype of

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -696,7 +696,7 @@ components:
           type: integer
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the image. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -11,6 +11,7 @@ info:
     - 1.2.0:
       - Change date to date-time
       - Add the impressionType, mimeType to biometricData
+      - Do not mix fixed properties and additional properties, use a subobject for the additional properties
     - 1.1.0:
       - Add error structure on 400 errors
       - Add signature in biometricType
@@ -628,7 +629,10 @@ components:
         country:
           type: string
           description: the country of the address
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
       example:
         address1: 11 Rue des Rosiers
         address2: '1st floor'
@@ -647,7 +651,7 @@ components:
         gender: M
         nationality: FRA
         email: john.doo@example.com
-        mobileNumber: +123456789
+        mobileNumber: "+123456789"
       additionalProperties: true
     BiometricData:
       type: object
@@ -860,7 +864,10 @@ components:
         parentCredentialId:
           type: string
           description: The ID credential used as a reference, or parent, to build a new one
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
       example:
         priority: MEDIUM
         credentialProfileId: ABC
@@ -936,7 +943,10 @@ components:
         serialNumber:
           type: string
           description: the serial number of the credential
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
     CredentialProfile:
       description: A credential profile
       type: object

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -8,6 +8,8 @@ info:
     
     Change log:
     
+    - 1.2.0:
+      - Change date to date-time
     - 1.1.0:
       - Add error structure on 400 errors
       - Add signature in biometricType
@@ -18,7 +20,7 @@ info:
       - Add a service to change the status
     - 1.0.0: Initial version
 
-  version: 1.1.0
+  version: 1.2.0
   title: OSIA Credential Management System Interface
   license:
     name: SIA
@@ -672,8 +674,8 @@ components:
           example: "http://imageserver.com/image?id=00003"
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
@@ -835,8 +837,8 @@ components:
         priority: MEDIUM
         credentialProfileId: ABC
         requestType: "FIRST_ISSUANCE"
-        validFromDate: "2020-10-08T18:38:56.085303"
-        validToDate: "2025-10-08T18:38:56.085303"
+        validFromDate: "2020-10-08T18:38:56Z"
+        validToDate: "2025-10-08T18:38:56Z"
         issuingAuthority: OSIA
         deliveryAddress:
           address1: 11 Rue des Rosiers
@@ -898,11 +900,11 @@ components:
         issuedDate:
           type: string
           format: date-time
-          description: The date that this credential was issued
+          description: The date and time that this credential was issued
         expiryDate:
           type: string
           format: date-time
-          description: The date that this credential expires
+          description: The date and time that this credential expires
         serialNumber:
           type: string
           description: the serial number of the credential

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -10,6 +10,7 @@ info:
     
     - 1.2.0:
       - Change date to date-time
+      - Add the impressionType, mimeType to biometricData
     - 1.1.0:
       - Add error structure on 400 errors
       - Add signature in biometricType
@@ -679,6 +680,8 @@ components:
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
+        impressionType:
+          $ref: '#/components/schemas/ImpressionType'
         width:
           type: integer
           description: the width of the image
@@ -687,6 +690,9 @@ components:
           description: the height of the image
         bitdepth:
           type: integer
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)
@@ -725,6 +731,28 @@ components:
           type: string
           enum: [BANDAGED, AMPUTATED, DAMAGED]
       additionalProperties: false
+    ImpressionType:
+      type: string
+      enum:
+        - LIVE_SCAN_PLAIN
+        - LIVE_SCAN_ROLLED
+        - NONLIVE_SCAN_PLAIN
+        - NONLIVE_SCAN_ROLLED
+        - LATENT_IMPRESSION
+        - LATENT_TRACING
+        - LATENT_PHOTO
+        - LATENT_LIFT
+        - LIVE_SCAN_SWIPE
+        - LIVE_SCAN_VERTICAL_ROLL
+        - LIVE_SCAN_PALM
+        - NONLIVE_SCAN_PALM
+        - LATENT_PALM_IMPRESSION
+        - LATENT_PALM_TRACING
+        - LATENT_PALM_PHOTO
+        - LATENT_PALM_LIFT
+        - LIVE_SCAN_OPTICAL_CONTACTLESS_PLAIN
+        - OTHER
+        - UNKNOWN
     BiometricType:
       type: string
       enum:

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -734,6 +734,9 @@ components:
         height:
           type: integer
           description: the height of the image in pixels
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         captureDate:
           type: string
           format: date-time
@@ -741,9 +744,6 @@ components:
         captureDevice:
           type: string
           description: A string identifying the device used to capture the document part
-        mimetype:
-          type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
       additionalProperties: false
     DocumentData:
       type: object

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -25,7 +25,7 @@ info:
       - Add fields on BiometricData: instance, metadata, comment, missing
     - 1.0.0: Initial version
 
-  version: 1.1.0
+  version: 1.2.0
   title: OSIA Enrollment Interface
   license:
     name: SIA

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -11,6 +11,8 @@ info:
     - 1.2.0:
       - Remove array for enrollmentFlags and requestData
       - Change date to date-time
+      - change mimetype to mimeType (upper case)
+      - Add , template, templateFormat to biometricData
     - 1.1.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -667,7 +669,7 @@ components:
           description: the height of the image
         bitdepth:
           type: integer
-        mimetype:
+        mimeType:
           type: string
           description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         resolution:
@@ -686,7 +688,19 @@ components:
         comment:
           type: string
           description: A comment about the biometric data
+        template:
+          type: string
+          format: byte
+          description: Base64-encoded template
+        templateFormat:
+          $ref: '#/components/schemas/TemplateFormat'
       additionalProperties: false
+    TemplateFormat:
+      type: string
+      description: |
+        Format of the template.
+        One of ISO_19794_2, ISO_19794_2_NS, ISO_19794_2_CS, ISO_19794_2_2011, ANSI_378_2009 or ANSI_378.
+        Can be extended to include additional proprietary template format
     MissingType:
       type: object
       properties:

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -8,6 +8,8 @@ info:
 
     Change log:
     
+    - 1.2.0:
+      - Remove array for enrollmentFlags and requestData
     - 1.1.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -578,13 +580,9 @@ components:
           type: string
           description: Type of the enrollment
         enrollmentFlags:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnrollmentFlags'
+          $ref: '#/components/schemas/EnrollmentFlags'
         requestData:
-          type: array
-          items:
-            $ref: '#/components/schemas/RequestData'
+          $ref: '#/components/schemas/RequestData'
         contextualData:
           $ref: '#/components/schemas/ContextualData'
         biographicData:
@@ -604,7 +602,11 @@ components:
       description: The data describing the request associated to the enrollment (i.e. why the enrollment is done). Can be extended.
       example:
         requestType: "IDCARD_ISSUANCE"
-        deliveryPlace: "paris"
+        deliveryAddress:
+          address1: 11 Rue des Rosiers
+          city: Libourne
+          postalCode: "33500"
+          country: France
         other: "other"
     EnrollmentFlags:
       type: object

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -671,7 +671,7 @@ components:
           type: integer
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the image. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)
@@ -736,7 +736,7 @@ components:
           description: the height of the image in pixels
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the document. The mime type definitions should be in compliance with RFC 6838.
         captureDate:
           type: string
           format: date-time

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -10,6 +10,7 @@ info:
     
     - 1.2.0:
       - Remove array for enrollmentFlags and requestData
+      - Change date to date-time
     - 1.1.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -651,8 +652,8 @@ components:
           example: "http://imageserver.com/image?id=00003"
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
@@ -721,8 +722,8 @@ components:
           description: the height of the image in pixels
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the document part

--- a/src/doc/yaml/notification.yaml
+++ b/src/doc/yaml/notification.yaml
@@ -423,7 +423,7 @@ components:
           description: URL to visit to confirm the subscription to a topic
         timestamp:
           type: string
-          format: datetime
+          format: date-time
       additionalProperties: false
     Topic:
       type: object

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -12,6 +12,8 @@ info:
       - Add an identityType in the identity object
       - rename documents in documentData in the identity object
       - Change date to date-time
+      - Mark the identityId as readOnly, add it to biometricData
+      - Add the impressionType, mimeType, template, templateFormat to biometricData
     - 1.3.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -1021,9 +1023,14 @@ components:
       additionalProperties: false
     Identity:
       type: object
+      required:
+        - status
+        - identityId
+        - identityType
       properties:
         identityId:
           type: string
+          readOnly: true
         identityType:
           type: string
         status:
@@ -1142,6 +1149,9 @@ components:
         instance:
           type: string
           description: Used to separate two distincts biometric items of the same type and subtype
+        identityId:
+          type: string
+          readOnly: true
         image:
           type: string
           format: byte
@@ -1158,6 +1168,8 @@ components:
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
+        impressionType:
+          $ref: '#/components/schemas/ImpressionType'
         width:
           type: integer
           description: the width of the image
@@ -1166,6 +1178,9 @@ components:
           description: the height of the image
         bitdepth:
           type: integer
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)
@@ -1182,7 +1197,19 @@ components:
         comment:
           type: string
           description: A comment about the biometric data
+        template:
+          type: string
+          format: byte
+          description: Base64-encoded template
+        templateFormat:
+          $ref: '#/components/schemas/TemplateFormat'
       additionalProperties: false
+    TemplateFormat:
+      type: string
+      description: |
+        Format of the template.
+        One of ISO_19794_2, ISO_19794_2_NS, ISO_19794_2_CS, ISO_19794_2_2011, ANSI_378_2009 or ANSI_378.
+        Can be extended to include additional proprietary template format
     MissingType:
       type: object
       properties:
@@ -1192,6 +1219,28 @@ components:
           type: string
           enum: [BANDAGED, AMPUTATED, DAMAGED]
       additionalProperties: false
+    ImpressionType:
+      type: string
+      enum:
+        - LIVE_SCAN_PLAIN
+        - LIVE_SCAN_ROLLED
+        - NONLIVE_SCAN_PLAIN
+        - NONLIVE_SCAN_ROLLED
+        - LATENT_IMPRESSION
+        - LATENT_TRACING
+        - LATENT_PHOTO
+        - LATENT_LIFT
+        - LIVE_SCAN_SWIPE
+        - LIVE_SCAN_VERTICAL_ROLL
+        - LIVE_SCAN_PALM
+        - NONLIVE_SCAN_PALM
+        - LATENT_PALM_IMPRESSION
+        - LATENT_PALM_TRACING
+        - LATENT_PALM_PHOTO
+        - LATENT_PALM_LIFT
+        - LIVE_SCAN_OPTICAL_CONTACTLESS_PLAIN
+        - OTHER
+        - UNKNOWN
     BiometricType:
       type: string
       enum:

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -8,6 +8,9 @@ info:
 
     Change log:
     
+    - 1.4.0:
+      - Add an identityType in the identity object
+      - rename documents in documentData in the identity object
     - 1.3.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -23,7 +26,7 @@ info:
       - Change the mandatory flag for the status, based on the type of service
     - 1.0.0: Initial version
 
-  version: 1.3.0
+  version: 1.4.0
   title: OSIA Population Registry Interface
   license:
     name: SIA
@@ -1020,6 +1023,8 @@ components:
       properties:
         identityId:
           type: string
+        identityType:
+          type: string
         status:
           type: string
           enum: [CLAIMED, VALID, INVALID, REVOKED]
@@ -1040,7 +1045,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BiometricData'
-        documents:
+        documentData:
           type: array
           items:
             $ref: '#/components/schemas/Document'

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -11,6 +11,7 @@ info:
     - 1.4.0:
       - Add an identityType in the identity object
       - rename documents in documentData in the identity object
+      - Change date to date-time
     - 1.3.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -1123,8 +1124,8 @@ components:
           $ref: '#/components/schemas/DocumentFormatType'
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the document part
@@ -1152,8 +1153,8 @@ components:
           example: "http://imageserver.com/image?id=00003"
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -1126,7 +1126,7 @@ components:
           description: the height of the image in pixels
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the document. The mime type definitions should be in compliance with RFC 6838.
         captureDate:
           type: string
           format: date-time
@@ -1178,7 +1178,7 @@ components:
           type: integer
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the image. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -14,6 +14,7 @@ info:
       - Change date to date-time
       - Mark the identityId as readOnly, add it to biometricData
       - Add the impressionType, mimeType, template, templateFormat to biometricData
+      - replace format with mimeType in documents
     - 1.3.0:
       - Add error structure on 400 errors
       - Add additional documentType and open it for extension
@@ -1077,10 +1078,6 @@ components:
       type: string
       enum: [NONE, WSQ, JPEG, JPEG2000, PNG]
 
-    DocumentFormatType:
-      type: string
-      enum: [NONE, JPEG, PNG, PDF]
-
     Document:
       type: object
       required:
@@ -1127,8 +1124,9 @@ components:
         height:
           type: integer
           description: the height of the image in pixels
-        format:
-          $ref: '#/components/schemas/DocumentFormatType'
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         captureDate:
           type: string
           format: date-time

--- a/src/doc/yaml/rp.yaml
+++ b/src/doc/yaml/rp.yaml
@@ -10,6 +10,8 @@ info:
 
     - 1.1.0:
       - Change date to date-time
+      - Add the encounterId to biometricData
+      - Add the impressionType, mimeType, template, templateFormat to biometricData
     - 1.0.0: Initial version
 
   version: 1.1.0
@@ -405,6 +407,9 @@ components:
         instance:
           type: string
           description: Used to separate two distincts biometric items of the same type and subtype
+        encounterId:
+          type: string
+          readOnly: true
         image:
           type: string
           format: byte
@@ -421,6 +426,8 @@ components:
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
+        impressionType:
+          $ref: '#/components/schemas/ImpressionType'
         width:
           type: integer
           description: the width of the image
@@ -429,6 +436,9 @@ components:
           description: the height of the image
         bitdepth:
           type: integer
+        mimeType:
+          type: string
+          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)
@@ -445,8 +455,41 @@ components:
         comment:
           type: string
           description: A comment about the biometric data
+        template:
+          type: string
+          format: byte
+          description: Base64-encoded template
+        templateFormat:
+          $ref: '#/components/schemas/TemplateFormat'
       additionalProperties: false
-  
+    TemplateFormat:
+      type: string
+      description: |
+        Format of the template.
+        One of ISO_19794_2, ISO_19794_2_NS, ISO_19794_2_CS, ISO_19794_2_2011, ANSI_378_2009 or ANSI_378.
+        Can be extended to include additional proprietary template format
+    ImpressionType:
+      type: string
+      enum:
+        - LIVE_SCAN_PLAIN
+        - LIVE_SCAN_ROLLED
+        - NONLIVE_SCAN_PLAIN
+        - NONLIVE_SCAN_ROLLED
+        - LATENT_IMPRESSION
+        - LATENT_TRACING
+        - LATENT_PHOTO
+        - LATENT_LIFT
+        - LIVE_SCAN_SWIPE
+        - LIVE_SCAN_VERTICAL_ROLL
+        - LIVE_SCAN_PALM
+        - NONLIVE_SCAN_PALM
+        - LATENT_PALM_IMPRESSION
+        - LATENT_PALM_TRACING
+        - LATENT_PALM_PHOTO
+        - LATENT_PALM_LIFT
+        - LIVE_SCAN_OPTICAL_CONTACTLESS_PLAIN
+        - OTHER
+        - UNKNOWN
     BiometricType:
       type: string
       enum:

--- a/src/doc/yaml/rp.yaml
+++ b/src/doc/yaml/rp.yaml
@@ -439,7 +439,7 @@ components:
           type: integer
         mimeType:
           type: string
-          description: the nature and format of a document. The mime type definitions should be in compliance with RFC 6838.
+          description: the nature and format of the image. The mime type definitions should be in compliance with RFC 6838.
         resolution:
           type: integer
           description: the image resolution (in DPI)

--- a/src/doc/yaml/rp.yaml
+++ b/src/doc/yaml/rp.yaml
@@ -50,7 +50,7 @@ paths:
           example: "1235567890"
         - name: identifierType
           in: query
-          description: Type of identifier (default "uin", "token", "documentNumber", ...)
+          description: Type of identifier (default "uin", "token", "credentialNumber", ...)
           required: false
           schema: 
             type: string
@@ -130,7 +130,7 @@ paths:
             example: "1235567890"
         - name: identifierType
           in: query
-          description: Type of identifier (default "uin", "token", "documentNumber", ...)
+          description: Type of identifier (default "uin", "token", "credentialNumber", ...)
           required: false
           schema: 
             type: string
@@ -187,7 +187,7 @@ paths:
             example: "1235567890"
         - name: identifierType
           in: query
-          description: Type of identifier (default "uin", "token", "documentNumber", ...)
+          description: Type of identifier (default "uin", "token", "credentialNumber", ...)
           required: false
           schema: 
             type: string

--- a/src/doc/yaml/rp.yaml
+++ b/src/doc/yaml/rp.yaml
@@ -12,6 +12,7 @@ info:
       - Change date to date-time
       - Add the encounterId to biometricData
       - Add the impressionType, mimeType, template, templateFormat to biometricData
+      - Do not mix fixed properties and additional properties, use a subobject for the additional properties
     - 1.0.0: Initial version
 
   version: 1.1.0
@@ -598,7 +599,10 @@ components:
         serialNumber:
           type: string
           description: the serial number of the credential
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false
 
     CredentialType:
       description: Type of the credential. e.g. "PASSPORT", "ID_CARD", ...
@@ -712,4 +716,7 @@ components:
         taskId:
           type: string
           example: '"123e4567-e89b-12d3-a456-426655440000"'
-      additionalProperties: true
+        others:
+          type: object
+          additionalProperties: true
+      additionalProperties: false

--- a/src/doc/yaml/rp.yaml
+++ b/src/doc/yaml/rp.yaml
@@ -1,11 +1,18 @@
+
 # (c) Secure Identity Alliance
+
 openapi: 3.0.0
 info:
   description: |
     The OSIA IDUsage Relying Party Interface
+    
     Change log:
+
+    - 1.1.0:
+      - Change date to date-time
     - 1.0.0: Initial version
-  version: 1.0.0
+
+  version: 1.1.0
   title: The OSIA IDUsage Relying Party Interface
   license:
     name: SIA
@@ -409,8 +416,8 @@ components:
           example: "http://imageserver.com/image?id=00003"
         captureDate:
           type: string
-          format: date
-          example: "2019-05-21"
+          format: date-time
+          example: "2019-05-21T12:00:00Z"
         captureDevice:
           type: string
           description: A string identifying the device used to capture the biometric
@@ -539,12 +546,12 @@ components:
             $ref: '#/components/schemas/CredentialType'
         issuedDate:
           type: string
-          format: date
-          description: The date that this credential was issued
+          format: date-time
+          description: The date and time that this credential was issued
         expiryDate:
           type: string
-          format: date
-          description: The date that this credential expires
+          format: date-time
+          description: The date and time that this credential expires
         serialNumber:
           type: string
           description: the serial number of the credential


### PR DESCRIPTION
Inconsistencies reviewed within the OSIA group on 26/11/2021:
- Make tequestData consistent between Enrollment and CMS
- Add an identityType in PR, similar to the encounterType in ABIS
- Use date-time format for all dates
- Align all definition of biometricData structure in all interfaces
- Use mimeType (uppercase 'T') in biographicData and documentData in all interfaces, and not format
- Use documentData instead of documents in PR
- Use scores and not scoreList for identity services in ABIS
- Fix implementation issues when an object has both fixed and additional properties