### PR TITLE
Use HTTP code 409 in case of confict of ID in create/move operations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ pyrsistent==0.18.0
 pytz==2021.1
 PyYAML==5.4.1
 requests==2.26.0
-sc-oa==0.7.0.8
+sc-oa==0.7.0.9
 six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.2.0

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -10,6 +10,7 @@ info:
 
     - 1.5.1:
       - Add missing values in BiometricSubType
+      - Use HTTP code 409 in case of conflict of ID in create/move operations
     - 1.5.0:
       - Add service to update only the galleries of an encounter
       - Change date to date-time
@@ -419,7 +420,7 @@ paths:
         Create one encounter in the person identified by his/her id.
         If the person does not yet exist, it is created automatically.
         
-        If the encounter already exists, an error 403 is returned.
+        If the encounter already exists, an error 409 is returned.
       operationId: createEncounter
       security:
         - BearerAuth: [abis.encounter.write]
@@ -489,7 +490,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: Creation not allowed
+          description: Operation not allowed
+        '409':
+          description: Creation not allowed, encounterId already exists
         '500':
           description: Unexpected error
           content:
@@ -896,7 +899,7 @@ paths:
       description: |
         Merge two sets of encounters into a single set. Merging a set of *N* encounters with a set of *M* encounters
         will result in a single set of *N+M* encounters. Encounter ID are preserved and in case of duplicates
-        an error is returned and no changes are done.
+        an error 409 is returned and no changes are done.
       operationId: mergeEncounter
       security:
         - BearerAuth: [abis.encounter.write]
@@ -951,7 +954,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: Merge not allowed
+          description: Operation not allowed
+        '409':
+          description: Merge not allowed, conflict of encounterId
         '404':
           description: Unknown record
         '500':
@@ -1011,7 +1016,7 @@ paths:
       summary: Move one encounter
       description: |
         Move one encounter from the source person to the target person.
-        Encounter ID is preserved and in case of duplicate an error is returned and no changes are done.
+        Encounter ID is preserved and in case of duplicate an error 409 is returned and no changes are done.
       operationId: moveEncounter
       security:
         - BearerAuth: [abis.encounter.write]
@@ -1072,7 +1077,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: Move not allowed
+          description: Operation not allowed
+        '409':
+          description: Move not allowed, conflict with the encounterId
         '404':
           description: Unknown record
         '500':
@@ -1709,6 +1716,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Identification not allowed
+        '404':
+          description: Unknown gallery
         '500':
           description: Unexpected error
           content:
@@ -1849,6 +1858,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Identification not allowed
+        '404':
+          description: Unknown person or gallery
         '500':
           description: Unexpected error
           content:
@@ -1995,6 +2006,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Identification not allowed
+        '404':
+          description: Unknown person, gallery or encounter
         '500':
           description: Unexpected error
           content:
@@ -2144,7 +2157,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '404':
-          description: Unknown record
+          description: Unknown person or gallery
         '403':
           description: Verification not allowed
         '500':

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -10,6 +10,7 @@ info:
     
     - 1.2.1:
       - Add missing values in BiometricSubType
+      - Use HTTP code 409 in case of conflict of ID in create operations
     - 1.2.0:
       - Change date to date-time
       - Add the impressionType, mimeType to biometricData
@@ -83,6 +84,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Operation not allowed
+        '409':
+          description: Creation not allowed, credentialRequestId already exists
         '500':
           description: Unexpected error
           content:

--- a/src/doc/yaml/enrollment.yaml
+++ b/src/doc/yaml/enrollment.yaml
@@ -10,6 +10,7 @@ info:
     
     - 1.2.1:
       - Add missing values in BiometricSubType
+      - Use HTTP code 409 in case of conflict of ID in create operations
     - 1.2.0:
       - Remove array for enrollmentFlags and requestData
       - Change date to date-time
@@ -88,8 +89,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Operation not allowed
-        '404':
-          description: Unknown record
+        '409':
+          description: Creation not allowed, enrollmentId already exists
         '500':
           description: Unexpected error
           content:

--- a/src/doc/yaml/pr.yaml
+++ b/src/doc/yaml/pr.yaml
@@ -10,6 +10,7 @@ info:
     
     - 1.4.1:
       - Add missing values in BiometricSubType
+      - Use HTTP code 409 in case of conflict of ID in create/move operations
     - 1.4.0:
       - Add an identityType in the identity object
       - rename documents in documentData in the identity object
@@ -186,6 +187,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Operation not allowed
+        '409':
+          description: Creation not allowed, personId already exists
         '500':
           description: Unexpected error
           content:
@@ -326,7 +329,7 @@ paths:
       summary: Merge two persons
       description: |
         Merge two person records into a single one. Identity ID are preserved and in case of duplicates
-        an error is returned and no changes are done.
+        an error 409 is returned and no changes are done.
         If the operation is successful, the person merged is deleted.
       operationId: mergePerson
       security:
@@ -361,6 +364,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Merge not allowed
+        '409':
+          description: Creation not allowed, conflict of identityId
         '404':
           description: Unknown record
         '500':
@@ -516,6 +521,8 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Insertion not allowed
+        '409':
+          description: Creation not allowed, identityId already exists
         '500':
           description: Unexpected error
           content:
@@ -731,7 +738,7 @@ paths:
       description: |
         Move one identity from the source person to the target person.
         Identity ID is preserved and in case of duplicate
-        an error is returned and no changes are done.
+        an error 409 is returned and no changes are done.
         The source person is not deleted, even if it was the only identity of this person.
       operationId: moveIdentity
       security:
@@ -774,6 +781,8 @@ paths:
           description: Move not allowed
         '404':
           description: Unknown record
+        '409':
+          description: Operation not allowed, conflict of identityId
         '500':
           description: Unexpected error
           content:


### PR DESCRIPTION
As approved during the OSIA monthly meeting of June, HTTP code 409 is now the preferred HTTP code in case of conflict of ID in create operations.
HTTP code 403 should be limited to security errors (insufficient privileges, etc.)