### PR TITLE
Callback management (abis.yaml updated)

### DIFF
--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -8,6 +8,10 @@ info:
     
     Change log:
 
+    - 1.6.0:
+      - Added methods to manage asychronous responses (callbacks):
+        - New Get Response Status method
+        - New Retrigger Response method
     - 1.5.1:
       - Add missing values in BiometricSubType
       - Use HTTP code 409 in case of conflict of ID in create/move operations
@@ -58,7 +62,7 @@ info:
       - Add service 'readAllEncounters'
     - 1.0.0: Initial version
 
-  version: 1.5.1
+  version: 1.6.0
   title: OSIA ABIS Interface
   license:
     name: SIA
@@ -2598,6 +2602,96 @@ paths:
                     application/json:
                       schema:
                         $ref: '#/components/schemas/Error'
+
+  /v1/tasks/{taskId}/status:
+    get:
+      tags:
+        - Task
+      summary: Read the execution status of an asynchronous transaction
+      operationId: readTaskStatus
+      security:
+        - BearerAuth: [abis.task.read]
+      parameters:
+        - name: taskId
+          in: path
+          description: id of the task of an asynchronous call
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Read successful. Asynchronous service execution status may be: 
+             -PENDING: service execution still in progress
+             -RESPONSE_SCHEDULED: service execution finished (successfully or with error), result will be returned by callback
+             -RESPONSE_ERROR: service execution finished (successfully or with error) but sending the result by callback failed (after max retries). No new attempt is planned except if a retrigger is requested using the redeliverTaskResult operation.
+             -RESPONSE_RETRY: service execution finished (successfully or with error) but sending the result by callback failed and a new attempt is planned (retriggering requested through redeliverTaskResult)
+             -COMPLETED: service execution finished and result was delivered successfully.
+          content:
+            application/json:
+              schema:
+                type: string
+                enum: [PENDING, RESPONSE_SCHEDULED, RESPONSE_ERROR, RESPONSE_RETRY, COMPLETED]
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Operation not allowed
+        '404':
+          description: Unknown task
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'  
+                
+  /v1/tasks/{taskId}/redeliver:
+    post:
+      tags:
+        - Task
+      summary: Trigger a new attempt to send a result by callback
+      description: |
+        Try to retrigger an asynchronous callback when:
+        - transaction is asynchronous
+        - response was never received, possibly because max retries was reached
+        - result is still available
+      operationId: redeliverTaskResult
+      security:
+        - BearerAuth: [abis.task.update]
+      parameters:
+        - name: taskId
+          in: path
+          description: id of the task of an asynchronous call
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: |
+            Retrigger successfully taken into account.
+            The callback will be called when the result is available.
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Invalid Operation (example: transaction is not Asynchronous, or result not/no more available)
+        '403':
+          description: Operation not allowed
+        '404':
+          description: Unknown task (never existed or removed e.g. after purge)
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   securitySchemes:

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -2618,6 +2618,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: transactionId
+          in: query
+          description: id of the transaction the taskId is attached to (used mainly for tracing purpose)
+          required: false
+          schema:
+            type: string     
       responses:
         '200':
           description: |
@@ -2657,7 +2663,7 @@ paths:
       description: |
         Try to retrigger an asynchronous callback when:
         - transaction is asynchronous
-        - response was never received, possibly because max retries was reached
+        - response was never received, possibly because max retries was reached (e.g. network failure)
         - result is still available
       operationId: redeliverTaskResult
       security:
@@ -2665,10 +2671,16 @@ paths:
       parameters:
         - name: taskId
           in: path
-          description: id of the task of an asynchronous call
+          description: id of the task of the asynchronous call to be re-delivered
           required: true
           schema:
             type: string
+        - name: transactionId
+          in: query
+          description: id of the transaction the taskId is attached to (used mainly for tracing purpose)
+          required: false
+          schema:
+            type: string     
       responses:
         '204':
           description: |
@@ -2681,7 +2693,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
         '409':
-          description: Invalid Operation (example: transaction is not Asynchronous, or result not/no more available)
+          description: |
+            Invalid Operation (example: transaction is not Asynchronous, or result not/no more available)
         '403':
           description: Operation not allowed
         '404':

--- a/src/doc/yaml/abis.yaml
+++ b/src/doc/yaml/abis.yaml
@@ -9,9 +9,9 @@ info:
     Change log:
 
     - 1.6.0:
-      - Added methods to manage asychronous responses (callbacks):
-        - New Get Response Status method
-        - New Retrigger Response method
+      - Added methods to manage asynchronous responses (callbacks):
+        - New Get Response Status method (readTaskStatus)
+        - New Retrigger Response method (redeliverTaskResult)
     - 1.5.1:
       - Add missing values in BiometricSubType
       - Use HTTP code 409 in case of conflict of ID in create/move operations
@@ -2621,7 +2621,7 @@ paths:
         - name: transactionId
           in: query
           description: id of the transaction the taskId is attached to (used mainly for tracing purpose)
-          required: false
+          required: true
           schema:
             type: string     
       responses:
@@ -2678,7 +2678,7 @@ paths:
         - name: transactionId
           in: query
           description: id of the transaction the taskId is attached to (used mainly for tracing purpose)
-          required: false
+          required: true
           schema:
             type: string     
       responses:
@@ -2692,13 +2692,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '409':
-          description: |
-            Invalid Operation (example: transaction is not Asynchronous, or result not/no more available)
         '403':
           description: Operation not allowed
         '404':
-          description: Unknown task (never existed or removed e.g. after purge)
+          description: Unknown task (never existed or removed e.g. after successful completion or purge)
         '500':
           description: Unexpected error
           content:


### PR DESCRIPTION
## 1.6.0: Added methods to manage asynchronous responses (callbacks)
o New Get Response Status method
o New Retrigger Response method
### Description
In the current OSIA ABIS API (and certainly all APIs with asynchronous result by callback), there are some lacks linked to asynchronous operations, at least:
- Get Transaction Status: 
o retrieve the status of a transaction (e.g. Insert, Search…)
- Retry Failed Result: 
o in case of callback not received/handled, be able to ask the OSIA module to trigger again this callback (e.g. after network failure).

In an operational point of view, we can’t reasonably consider that we have no view on a transaction status, and no way to get a missed result. 
And that any client should send again the same command to hope having a result next time.
Such lack requires to complexify the client process by managing a functional retry (clone the transaction) for a transaction which is possibly already completed and its result available (if not purged…).
We could consider that all transaction results will be deleted/purged (e.g. after successful delivery via callback, but also after a predefined period), but it should be done after a configured time (e.g. after 1 day) (or manually during an operational process). It means that, during a preconfigured period, we should be able to ask again for a result by callback if we detect that we missed it.
### Remark
Should be applicable for all modules with asynchronous responses (callbacks), not only ABIS.