### PR TITLE
Updates to credential request APIs in CMS

### DIFF
--- a/src/doc/02 - functional.rst
+++ b/src/doc/02 - functional.rst
@@ -216,6 +216,10 @@ The following table describes in detail the interfaces and associated services.
     Create Credential Request          Request issuance of a secure credential
     Read Credential Request            Retrieve the data/status of a credential request
     Update Credential Request          Update the requested issuance of a secure credential
+    Update Request Delivery Address    Update the delivery address of a credential request
+    Update Request Priority            Update the priority of a credential request
+    Hold Credential Request            Put the credential request on hold
+    Release Credential Request         Release the hold on the credential request
     Cancel Credential Request          Cancel the requested issuance of a secure credential
     Find Credentials                   Retrieve a list of credentials that match the passed in search criteria
     Read Credential                    Retrieve the attributes/status of an issued credential (smart card, mobile, passport, etc.)

--- a/src/doc/06 - building blocks.rst
+++ b/src/doc/06 - building blocks.rst
@@ -170,6 +170,10 @@ The following table maps the interfaces described in :ref:`chapter-interfaces` a
     Create Credential Request                                                             I
     Read Credential Request                                                               I
     Update Credential Request                                                             I
+    Update Request Delivery Address                                                       I
+    Update Request Priority                                                               I
+    Hold Credential Request                                                               I
+    Release Credential Request                                                            I
     Cancel Credential Request                                                             I
     Find Credentials                                                                      I
     Read Credential                                                                       I

--- a/src/doc/functional/_cms.rst
+++ b/src/doc/functional/_cms.rst
@@ -47,6 +47,56 @@ Services
         e.g. credential lifetime if overriding default, delivery addresses, etc.
     :return: a status indicating success or error.
 
+.. py:function:: updateCredentialRequestMailingAddress(credentialRequestID, deliveryAddress, transactionID)
+    :noindex:
+
+    Update the delivery address of a credential request.
+
+    **Authorization**: ``cms.request.write``
+
+    :param str credentialRequestID: The ID of the credential request.
+    :param string transactionID: The client generated transactionID.
+    :param dict deliveryAddress: Delivery address attributes, e.g. address1, city, state, postalCode, country, etc.
+    :return: a status indicating success or error.
+
+.. py:function:: updateCredentialRequestPriority(credentialRequestID, priority, transactionID)
+    :noindex:
+
+    Update the priority of a credential request.
+
+    **Authorization**: ``cms.request.write``
+
+    :param str credentialRequestID: The ID of the credential request.
+    :param string transactionID: The client generated transactionID.
+    :param int priority: New priority to be applied to the credential request.
+    :return: a status indicating success or error.
+
+.. py:function:: holdCredentialRequest(credentialRequestID, reason, comment, transactionID)
+    :noindex:
+
+    Place the requested issuance of a secure credential on hold.
+
+    **Authorization**: ``cms.request.write``
+
+    :param str credentialRequestID: The ID of the credential request.
+    :param string reason: The reason for the hold.
+    :param string comment: Comments related to the hold, optional.
+    :param string transactionID: The client generated transactionID.
+    :return: a status indicating success or error.
+
+.. py:function:: releaseCredentialRequest(credentialRequestID, reason, comment, transactionID)
+    :noindex:
+
+    Release the hold on the requested issuance of a secure credential.
+
+    **Authorization**: ``cms.request.write``
+
+    :param str credentialRequestID: The ID of the credential request.
+    :param string reason: The reason for releasing the hold.
+    :param string comment: Comments related to the release, optional.
+    :param string transactionID: The client generated transactionID.
+    :return: a status indicating success or error.
+
 .. py:function:: cancelCredentialRequest(credentialRequestID, transactionID)
     :noindex:
 

--- a/src/doc/yaml/cms.yaml
+++ b/src/doc/yaml/cms.yaml
@@ -8,6 +8,11 @@ info:
     
     Change log:
     
+    - 1.2.2:
+      - Add updateCredentialRequestMailingAddress, updateCredentialRequestPriority, holdCredentialRequest, releaseCredentialRequest
+      - Add HOLD to CredentialRequest status enum
+      - Add credentialRequestNumber to CredentialRequest
+      - Add personNumber to CredentialRequest and CredentialData
     - 1.2.1:
       - Add missing values in BiometricSubType
       - Use HTTP code 409 in case of conflict of ID in create operations
@@ -190,6 +195,208 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+
+  /v1/credentialRequests/{credentialRequestId}/updateDeliveryAddress:
+    put:
+      tags:
+        - Credential Request
+      summary: Update the delivery address of a credential request
+      operationId: updateCredentialRequestMailingAddress
+      security:
+        - BearerAuth: [cms.request.write]
+      parameters:
+        - name: credentialRequestId
+          in: path
+          description: the id of the credential request
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - deliveryAddress
+              properties:
+                deliveryAddress:
+                  $ref: '#/components/schemas/Address'
+      responses:
+        '201':
+          description: Operation successful
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Operation not allowed
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/credentialRequests/{credentialRequestId}/changePriority:
+    post:
+      tags:
+        - Credential Request
+      summary: Change the priority of a credential request
+      operationId: updateCredentialRequestPriority
+      security:
+        - BearerAuth: [cms.request.write]
+      parameters:
+        - name: credentialRequestId
+          in: path
+          description: the id of the credential request
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - priority
+              properties:
+                priority:
+                  type: integer
+                  description: "the request priority (0: lowest priority; 9: highest priority)"
+      responses:
+        '201':
+          description: Operation successful
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Operation not allowed
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/credentialRequests/{credentialRequestId}/hold:
+    post:
+      tags:
+        - Credential Request
+      summary: Put the credential request on hold
+      operationId: holdCredentialRequest
+      security:
+        - BearerAuth: [cms.request.write]
+      parameters:
+        - name: credentialRequestId
+          in: path
+          description: the id of the credential request
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  description: "the reason for the hold"
+                comment:
+                  type: string
+                  description: "additional comments related to the hold"
+      responses:
+        '201':
+          description: Operation successful
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Operation not allowed
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /v1/credentialRequests/{credentialRequestId}/release:
+    post:
+      tags:
+        - Credential Request
+      summary: Release the hold on the credential request
+      operationId: releaseCredentialRequest
+      security:
+        - BearerAuth: [cms.request.write]
+      parameters:
+        - name: credentialRequestId
+          in: path
+          description: the id of the credential request
+          required: true
+          schema:
+            type: string
+        - name: transactionId
+          in: query
+          description: The id of the transaction
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+                  description: "the reason for releasing the hold"
+                comment:
+                  type: string
+                  description: "additional comments related to the release"
+      responses:
+        '201':
+          description: Operation successful
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Operation not allowed
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /v1/credentialRequests/{credentialRequestId}/cancel:
     post:
       tags:
@@ -926,6 +1133,7 @@ components:
           city: Libourne
           postalCode: "33500"
           country: France
+
     CredentialRequest:
       type: object
       description: A request for a credential
@@ -938,14 +1146,21 @@ components:
           type: string
           description: The unique id of this credential request
           readOnly: true
+        credentialRequestNumber:
+          type: string
+          description: The credential request number for this credential request
+          readOnly: true
         status:
           type: string
-          enum: [PENDING, ISSUED, CANCELLED, FAILED]
+          enum: [PENDING, ISSUED, HOLD, CANCELLED, FAILED]
         requestData:
           $ref: '#/components/schemas/RequestData'
         personId:
           type: string
           description: The id of the person who is the target of the request
+        personNumber:
+          type: string
+          description: The number attached to the person who is the target of the request
         biographicData:
           $ref: '#/components/schemas/BiographicData'
         biometricData:
@@ -989,6 +1204,9 @@ components:
         personId:
           type: string
           description: The unique id of the person that the credential request is for
+        personNumber:
+          type: string
+          description: The number attached to the person who is the target of the request
         credentialProfileId:
           type: string
           description: The unique id of the credential profile


### PR DESCRIPTION
Adding Credential Request APIs:
- updateCredentialRequestMailingAddress
   - The intent is to update deliveryAddress of a CredentialRequest without being forced to provide all other details, as is functionally required by updateCredentialRequest (HTTP PUT)
- updateCredentialRequestPriority
   - Only update the CredentialRequest's priority.
- holdCredentialRequest
   - Apply a temporary hold on a credential request.
- releaseCredentialRequest
   - Release a temporary hold that was previously applied on a credential request; status reverted to PENDING

Adding supporting attributes:
- credentialRequestNumber
   - Human readable identifier added to the CredentialRequest object
- personNumber
   - Human readable identifier accompanying the personId; added to CredentialRequest and RequestData objects.
- HOLD status
   - Adding HOLD option to CredentialRequest object's status enum; required to support holdCredentialRequest and releaseCredentialRequest

